### PR TITLE
Add Working Group Life Cycle

### DIFF
--- a/working-group-lifecycle.md
+++ b/working-group-lifecycle.md
@@ -45,8 +45,10 @@ progress a project will move to `End-of-Life`. The details for each phase follow
 
 ## To become `Active`:
 
-* Have met at least 20 times
-* Have at least 10 regular members
+* Have received TAC approval of the readme.md per `Incubating` requirements above
+* Have met at least 4 times over a period of at least 2 months since becoming `Incubating`
+* Have at least 5 regular members from at least 3 different organizations attending regularly as
+recorded in meeting minutes.
 * Request TAC approval. TAC will vote to approve or provide constructive guidance
 
 ## Once `Active`:

--- a/working-group-lifecycle.md
+++ b/working-group-lifecycle.md
@@ -1,0 +1,67 @@
+# Working Group Life Cycle
+
+Contributors interested in starting a new working group are encouraged to first review the existing
+working groups and projects. It is very likely that an existing working group could be extended to
+cover the new topic. In that case please bring your time and energy into that existing working
+group. Your contributions are very welcome!
+
+However, if no existing effort covers the topic feel free to make use of the existing working group
+meetings, mail lists, and/or slack channels to solicit support for a new working group.
+
+Please note that running a working group successfully requires an extended effort.
+Be prepared to commit at least several hours per week for a year or more.
+
+The Working Group Life Cycle begins with establishing commitments from other interested
+contributors then making a proposal to the Technical Advisory Committee (TAC). If accepted, the
+Working Group will begin as `Incubating`. This is a boot strapping phase for the group to adopt
+OpenSSF community policies and norms. Once those are met the group becomes `Active` and will be
+fully recognized in OpenSSF. Either upon completing its objectives or no longer making forward
+progress a project will move to `End-of-Life`. The details for each phase follow.
+
+## To become `Incubating`
+
+* Proposal of scope for review by TAC
+    * This is to help ensure limited overlap with existing WG
+* Have met at least 5 times
+    * For these, meeting notes (or ideally recordings) are public
+* Have at least 5 interested individuals from at least 3 different organizations attending regularly
+* 1 TAC sponsor
+    * TAC sponsor agrees to attend WG meetings regularly
+    * TAC sponsor does not need to have a formal role in WG, e.g., chair
+    * TAC sponsor requests TAC approval 
+* TAC will vote to approve or provide constructive guidance
+
+## Once `Incubating`:
+
+* Operate as part of the OpenSSF adhering to community policies
+* Deliver quarterly reviews to TAC
+* Complete and request TAC approval of [readme.md](https://github.com/ossf/project-template/blob/main/README.md)
+* Meet on a regular cadence. Meetings are public, recorded, and on the calendar
+* Have access to community resources (Zooms, YouTube channels, GitHub, Slack channels, etc.)
+* Can request funding/other resources (subject to TAC/GB approval)
+    * NOTE: _At the time of this draft, funding and resources beyond collaboration tools have not been established in the OpenSSF. Working groups should expect that their main resource is the community contributions they are able to recruit._
+
+## To become `Active`:
+
+* Have met at least 20 times
+* Have at least 10 regular members
+* Request TAC approval. TAC will vote to approve or provide constructive guidance
+
+## Once `Active`
+
+* (same as incubating, plus)
+* Have at least annual goals and metrics for success
+
+## To become `End-of-Life`
+
+* Work has stopped
+    * The Working Group has completed its chartered deliverables
+    or
+    * The Working Group is no longer progressing on its deliverables as determined by the TAC
+* In either case the TAC will vote to formally end the Working Group
+
+## Once `End-of-Life`
+
+* All significant artifacts should be archived as appropriate
+* Meeting series removed from calendar, mail list closed, and any other administrative items
+  similarly put to closure as needed

--- a/working-group-lifecycle.md
+++ b/working-group-lifecycle.md
@@ -2,11 +2,11 @@
 
 Contributors interested in starting a new working group are encouraged to first review the existing
 working groups and projects. It is very likely that an existing working group could be extended to
-cover the new topic. In that case please bring your time and energy into that existing working
+cover the new topic. If this is the case, please bring your time and energy into that existing working
 group. Your contributions are very welcome!
 
 However, if no existing effort covers the topic feel free to make use of the existing working group
-meetings, mail lists, and/or slack channels to solicit support for a new working group.
+meetings, mailing lists, and/or Slack channels to solicit support for a new working group.
 
 Please note that running a working group successfully requires an extended effort.
 Be prepared to commit at least several hours per week for a year or more.

--- a/working-group-lifecycle.md
+++ b/working-group-lifecycle.md
@@ -18,7 +18,7 @@ OpenSSF community policies and norms. Once those are met the group becomes `Acti
 fully recognized in OpenSSF. Either upon completing its objectives or no longer making forward
 progress a project will move to `End-of-Life`. The details for each phase follow.
 
-## To become `Incubating`
+## To become `Incubating`:
 
 * Proposal of scope for review by TAC
     * This is to help ensure limited overlap with existing WG
@@ -39,7 +39,9 @@ progress a project will move to `End-of-Life`. The details for each phase follow
 * Meet on a regular cadence. Meetings are public, recorded, and on the calendar
 * Have access to community resources (Zooms, YouTube channels, GitHub, Slack channels, etc.)
 * Can request funding/other resources (subject to TAC/GB approval)
-    * NOTE: _At the time of this draft, funding and resources beyond collaboration tools have not been established in the OpenSSF. Working groups should expect that their main resource is the community contributions they are able to recruit._
+    * NOTE: _At the time of this draft, funding and resources beyond collaboration tools have not
+    been established in the OpenSSF. Working groups should expect that their main resource is the
+    community contributions they are able to recruit._
 
 ## To become `Active`:
 
@@ -47,12 +49,12 @@ progress a project will move to `End-of-Life`. The details for each phase follow
 * Have at least 10 regular members
 * Request TAC approval. TAC will vote to approve or provide constructive guidance
 
-## Once `Active`
+## Once `Active`:
 
 * (same as incubating, plus)
 * Have at least annual goals and metrics for success
 
-## To become `End-of-Life`
+## To become `End-of-Life`:
 
 * Work has stopped
     * The Working Group has completed its chartered deliverables
@@ -60,7 +62,7 @@ progress a project will move to `End-of-Life`. The details for each phase follow
     * The Working Group is no longer progressing on its deliverables as determined by the TAC
 * In either case the TAC will vote to formally end the Working Group
 
-## Once `End-of-Life`
+## Once `End-of-Life`:
 
 * All significant artifacts should be archived as appropriate
 * Meeting series removed from calendar, mail list closed, and any other administrative items


### PR DESCRIPTION
The initial draft of the working group life cycle is based on
https://github.com/ossf/tac/issues/13 and TAC discussions leading up to
the 2020-12-01 meeting.

It is intended to satisfy the Open SSF Charter item 6.e.iii:
[The TAC will be responsible for: ...]
"iii) creating, maintaining and amending project lifecycle states, review
procedures and processes;"

Signed-off-by: Dan Middleton <dan.middleton@intel.com>