### PR TITLE
Update issue template for new org/team

### DIFF
--- a/.github/ISSUE_TEMPLATE/join-the-openssf-github-org.md
+++ b/.github/ISSUE_TEMPLATE/join-the-openssf-github-org.md
@@ -1,0 +1,28 @@
+---
+name: Join the OpenSSF GitHub org
+about: For members requesting access to the OpenSSF GitHub org
+title: "[GitHub org request] Add organization/team"
+labels: ''
+assignees: LindsayLF, rhaning
+
+---
+
+I'd like to add
+- [ ] an organization
+- [ ] an individual
+
+### Organization - create a team
+
+If your organization is a [member of OpenSSF](https://openssf.org/about/members/), we will [create a GitHub team](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/about-teams) for you to manage individual membership.
+
+Please provide the GitHub handle(s) of your desired team maintainers: 
+
+They will be responsible for adding any new team members to the appropriate team.
+
+### Individual - get access to the org
+
+If you're not part of the OpenSSF GitHub org, you can be added. You do not need to be part of an organization which is a member of OpenSSF.
+
+Please provide your GitHub handle:
+
+If you're part of a member organization of the OpenSSF, please [ask to be added to the appropriate team](https://github.com/orgs/ossf/teams).


### PR DESCRIPTION
Draft for an issue template for adding org/team members.
* A user can request to be added to the GitHub org
* An org can request that we create a new team for their org within the GitHub org

I think the use case we still need to figure out is new individuals in an existing member org. As far as I can tell, unless we make those who are team maintainers for the teams also org admins, they can't add *individuals* to the GitHub org.