### PR TITLE
Add an initial "working group abilities" document.

### DIFF
--- a/working-group-abilities.md
+++ b/working-group-abilities.md
@@ -1,0 +1,53 @@
+# Working Group Abilities
+
+Established working groups in the OpenSSF are given broad latitude to accomplish their goals.
+The TAC aims to only require formal approval in limited cases.
+This document outlines some of the explicitly permitted activities and resources made
+available to working groups.
+
+
+As per the OpenSSF [charter/FAQ](https://openssf.org/#faq), the TAC is not directly in charge
+of sub initiatives.
+These are intended to run themselves, and are expected to make most decisions without needing
+to ask the TAC for permission.
+With this in mind, this document is not exhaustive and will grow over time - it is intended to
+outline the processes for some common requests and resources.
+
+When in doubt, reach out to the TAC with any questions!
+
+## Repositories
+
+We expect that working groups will need to create repositories for code, tools, and other projects.
+These should be created in the [ossf](github.com/ossf) organization where possible to simplify
+management.
+
+Working groups can also request new organizations where necessary - reach out to the TAC for
+logistics.
+
+
+If any of these projects grow large enough, they can be "spun-off" into separate working groups by
+the TAC.
+As a general rule-of-thumb, if a sub-project requires its own standing meeting, it might be time to
+spin-it-off.
+
+## Papers
+
+As the working groups are intended to be the subject matter experts in their domains,
+they should author papers for release through the OpenSSF without review or approval from the TAC.
+However, the TAC does ask that drafts be shared as early as possible (hopefully >7 days) for
+feedback and awareness.
+Drafts can be shared by sending email to openssf-tac@lists.openssf.org.
+
+Once completed, working groups should work with the Governing Board to communicate, promote, and
+market the published papers in accordance with the general OpenSSF communication strategy.
+
+All papers should still follow open source best practices including transparency in development and
+avoiding vendor bias.
+
+## Technical Infrastructure
+
+Working groups are free to use whatever resources they can find, or to solicit help from member
+organizations, or to request funding from the OpenSSF Governing Board, through the TAC.
+
+The TAC asks that working groups keep them informed of what infrastructure they are using for
+awareness as we begin the process of collecting formal resources.


### PR DESCRIPTION
This builds on @dcmiddle's draft at #44. I tried to simplify out the parts that were closer to consensus from that discussion to get something started.

I tried to not bring up the distinction between Project and Working Group here until we get a better idea on why we need to have one.