### PR TITLE
Update list of WGs to include Supply Chain Integrity WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following Technical Initatives have been approved by the TAC:
 | Security Best Practices                              | https://github.com/ossf/wg-best-practices-os-developers       | [Meeting Notes](https://github.com/ossf/wg-best-practices-os-developers/blob/main/meeting-minutes.md) | Incubating |
 | Identifying Security Threats                         | https://github.com/ossf/wg-identifying-security-threats       | [Meeting Notes](https://docs.google.com/document/d/1AfI0S6VjBCO0ZkULCYZGHuzzW8TPqO3zYxRjzmKvUB4/edit) | Incubating |
 | Securing Critical Projects                           | https://github.com/ossf/wg-securing-critical-projects         | [Meeting Notes](https://docs.google.com/document/d/1MIXxadtWsaROpFcJnBtYnQPoyzTCIDhd0IGV8PIV0mQ/edit) | Incubating |
-| Developer Identity Verification                      | https://github.com/ossf/wg-developer-identity                 | [Meeting Notes](https://docs.google.com/document/d/1xPs2sSbH3I9Ich7OyLOzl85oJshnK8Q6WoAgREE5-zA/edit) | Incubating |
+| Supply Chain Integrity                               | https://github.com/ossf/wg-supply-chain-integrity             | [Meeting Notes](https://docs.google.com/document/d/1xPs2sSbH3I9Ich7OyLOzl85oJshnK8Q6WoAgREE5-zA/edit) | Incubating |
 
 Charters for these Technical Intiatives are located in the [Charters](charters)
 directory of this repository.


### PR DESCRIPTION
According to its repository, the Developer Identity Verification WG
has been renamed to Supply Chain Integrity WG. [0]
The Git repository also redirects to the repo named wg-supply-chain-integrity.
This commit updates the table listing WGs accordingly.

[0] https://github.com/ossf/wg-supply-chain-integrity#supply-chain-integrity-wg-formerly-digital-identity-attestation-wg