### PR TITLE
Add github settings file

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,32 @@
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+
+  # The name of the repository. Changing this will rename the repository
+  name: tac
+
+  # A short description of the repository that will show up on GitHub
+  description: The OpenSSF Technical Advisory Council (TAC) is responsible for structuring and facilitating collaboration among the Technical Initiatives.
+
+  # A URL with more information about the repository
+  homepage: https://openssf.org/about/tac/
+
+  # Collaborators: give specific users access to this repository.
+  # see /governance/roles.md for details on write access policy
+  # note that the permissions below may provide wider access than needed for
+  # a specific role, and we trust these individuals to act according to their
+  # role. If there are questions, please contact one of the chairs.
+collaborators:
+  # Chairs and Admin Help
+  #- username: 
+  #  permission: admin
+
+labels:
+  - name: helpwanted
+    color: ffff54
+  - name: good first issue
+    color: ff8c00
+  - name: meeting
+    color: 00ff00
+
+# additional colors in this palette:
+# 7f0000 , 1e90ff, ffdab9, ff69b4


### PR DESCRIPTION
Adds description with pointer to webpage.
Gives admin access to chair and vice-chair and push access
to the other TAC members.

This addresses Issues #28 and #16

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>