### PR TITLE
Separate WGs and Projects lifecycles Take 2

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -1,35 +1,7 @@
 
-<!-- TOC -->
-
-- [I. Overview](#i-overview)
-- [II. Lifecycle](#ii-lifecycle)
-    - [Stages - Definitions & Expectations](#stages---definitions--expectations)
-        - [Sandbox](#sandbox)
-            - [Gives - Review and Reporting](#gives---review-and-reporting)
-            - [Gets - Benefits](#gets---benefits)
-            - [Sandbox Entry Requirements](#sandbox-entry-requirements)
-            - [Project Graduation Process: Sandbox to Incubating](#project-graduation-process-sandbox-to-incubating)
-            - [Submission Forms for Sandbox](#submission-forms-for-sandbox)
-            - [Submission Forms for Sandbox to Incubating](#submission-forms-for-sandbox-to-incubating)
-        - [Incubating](#incubating)
-            - [Gives - Review and Reporting](#gives---review-and-reporting)
-            - [Gets - Benefits](#gets---benefits)
-            - [Incubating Entry Requirements](#incubating-entry-requirements)
-            - [Project Graduation Process: Incubating to Graduation](#project-graduation-process-incubating-to-graduation)
-            - [Submission Forms for Incubating](#submission-forms-for-incubating)
-            - [Submission Forms for Incubating to Graduation](#submission-forms-for-incubating-to-graduation)
-        - [Graduated](#graduated)
-            - [Gives - Review and Reporting](#gives---review-and-reporting)
-            - [Gets - Benefits](#gets---benefits)
-            - [Project Graduation Process: Graduated to Archiving](#project-graduation-process-graduated-to-archiving)
-            - [Submission Forms for Graduated to Archived](#submission-forms-for-graduated-to-archived)
-        - [Archived](#archived)
-
-<!-- /TOC -->
-
 # I. Overview
 
-This policy describes the Open Source Security Foundation (OpenSSF) project life cycle process for Working Group to Project, adding an existing external Project as an OpenSSF Project, and transferring an existing Project from a different Linux Foundation organization, CNCF or CDF.
+This document describes the Open Source Security Foundation (OpenSSF) life cycle process for Technical Initiatives, both Working Groups and Projects.
 
 The authority that governs this process is as follows:
 
@@ -51,132 +23,11 @@ The process is designed to be flexible to enable a Project to move in and out of
 
 # II. Lifecycle
 
-Each Working Group and Project will follow the sandbox, incubating, graduated and archival lifecycle stages.
+There are two different types of projects within OpenSSF: software focused projects and non-software focused projects. As the names imply, the primary goal of software-focused projects is to develop a piece of software while the primary goal of non-software focused projects is not. The primary goal of non-software projects can be to develop a guide, some educational material, or conduct an outreach operation for instance.
 
-The lifecycle progression, movement from one stage to another, allows them to participate at the level that is most appropriate for them given where they are at.
+Working Groups, software focused projects, and non-software focused projects have different lifecycles as defined below:
 
-## Stages - Definitions & Expectations
-
-Working Groups and Projects have a maturity level of sandbox, incubating, or graduated. Archived is for Working Groups and Projects no longer in active development. The maturity level is a signal by OpenSSF as to what sorts of enterprises should be adopting different projects. Working Groups and Projects increase their maturity by demonstrating their sustainability to OpenSSF’s Technical Advisory Committee(TAC): that they have adoption, a healthy rate of changes, committers from multiple organizations, have adopted the OpenSSF Code of Conduct, and have achieved and maintained the Core Infrastructure Initiative Best Practices Badge.
-
-![Project Stages](/process/project-stages.png)
-
-### Sandbox
-
-The OpenSSF Sandbox is the entry point for early stage Working Groups and Projects and has four goals:
-
-* Encourage public visibility of experiments or other early work that can add value to the OpenSSF mission and build the ingredients of a successful Incubation level Working Group or Project
-* Facilitate alignment with existing Working Groups or Projects if (and only if) this is desired
-* Nurture Working Groups and Projects (e.g. via OpenSSF Service Desk requests)
-* Remove possible legal and governance obstacles to adoption and contribution by ensuring all projects adhere to OpenSSF legal, code of conduct and IP Policy requirements.
-
-#### Gives - Review and Reporting
-*** Need Text ***
-
-#### Gets - Benefits
-*** Need Text ***
-
-#### Sandbox Entry Requirements
-
-Working Groups and Projects being submitted to the OpenSSF at the sandbox level are intended to be the entry point for early stage projects and are not required to undergo due diligence.
-
-Sandbox Working Groups and Projects should be early-stage projects that the OpenSSF TAC believes warrant experimentation.
-
-* New Working Groups and Projects that are designed to extend one or more OpenSSF Projects with functionality or interoperability libraries.
-* Independent projects that fit the OpenSSF mission and provide potential for a novel approach to existing functional areas (or are an attempt to meet an unfulfilled need)
-* Projects commissioned or sanctioned by the OpenSSF, including initial code for OpenSSF WG collaborations, and "experimental" projects
-* Any project that realistically intends to join OpenSSF Incubation in future and wishes to lay the foundations for that
-
-#### Project Graduation Process: Sandbox to Incubating
-
-Incubating Working Groups and Projects are required to undergo due diligence as a part of the process to move from Sandbox to Incubation. Due Diligence is driven by a TAC sponsor, with two weeks for public comment before a vote is called.
-
-#### Submission Forms for Sandbox
-
-1. [Proposal](TBD)
-2. [Legal](TBD)
-
-#### Submission Forms for Sandbox to Incubating
-
-1. [Proposal](TBD)
-2. [Legal](TBD)
-
-### Incubating
-
-![Incubating](/process/incubation-process.png)
-
-#### Gives - Review and Reporting
-*** Need Text ***
-
-#### Gets - Benefits
-*** Need Text ***
-
-#### Incubating Entry Requirements
-
-To be accepted to incubating stage, a project must meet the sandbox stage requirements plus:
-
-* Document that it is being used successfully in production by at least three independent end users which, in the TAC’s judgement, are of adequate quality and scope.
-* Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
-* Demonstrate a substantial ongoing flow of commits and merged contributions.
-* Since these metrics can vary significantly depending on the type, scope and size of a project, the TAC has final judgement over the level of activity that is adequate to meet these criteria
-* A clear versioning scheme.
-* Specifications must have at least one public reference implementation.
-
-#### Project Graduation Process: Incubating to Graduation
-
-Projects that wish to move from Incubating to Graduation should open a PR confirming the following criteria:
-* Have committers from at least two organizations.
-* Have achieved and maintained a [Core Infrastructure Initiative Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
-* Have completed an independent and third party security audit with results published of similar scope and quality as [this example](https://github.com/envoyproxy/envoy#security-audit) which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
-* Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
-* Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
-* Please include a short one-page narrative based off the Graduation template, no more than 500 words.
-
-#### Submission Forms for Incubating
-
-1. [Proposal](TBD)
-2. [Legal](TBD)
-
-#### Submission Forms for Incubating to Graduation
-
-1. [Proposal](TBD)
-2. [Legal](TBD)
-
-### Graduated
-
-Graduated projects signal the highest level of maturity for a OpenSSF project.
-
-#### Gives - Review and Reporting
-*** Need Text ***
-
-#### Gets - Benefits
-*** Need Text ***
-
-#### Project Graduation Process: Graduated to Archiving
-
-Open source projects have a lifecycle and there are times that projects become inactive due to a variety of reasons. There are also cases where a project may no longer want to be supported by the TAC, or the TAC may no longer wish to recommend the use of a project.
-Archiving Criteria
-When voting on a proposal to archive a project, TAC members may wish to consider whether the project continues to meet the criteria for OpenSSF acceptance. The TAC may also look at activity levels in the project (https://all.devstats.cncf.io/d/53/projects-health-table?orgId=1), although it is important to note that there is a difference between a mature project that doesn't get much attention any more but is stable, versus a project that is inactive.
-
-#### Submission Forms for Graduated to Archived
-
-1. [Proposal](TBD)
-2. [Legal](TBD)
-
-### Archived
-
-Archived projects are no longer in active development and are only archived after a TAC vote.
-
-What does archiving for a OpenSSF project mean?
-* OpenSSF will no longer provide support for the project via service desk
-* OpenSSF will list archived projects online
-* Trademarks and domain names of archived projects are still hosted by the OpenSSF and the Linux Foundation
-* OpenSSF can provide services such as documentation updates to help transition users.
-* Other OpenSSF marketing activities will no longer be provided for the project
-
-To archive a project:
-* A proposal must be put forth to the TAC repo
-* The TAC will inform the project maintainers, OpenSSF end user community and wider community of all archiving proposals
-* The proposal must remain open for at least 2 weeks of discussion after the maintainers are informed.
-* A vote must be finalized with 2/3 approval from the TAC
+* [Working Group Life Cycle](working-group-lifecycle.md)
+* [Software focused project Life Cycle](software-project-lifecycle.md)
+* [Non-software focused project Life Cycle](non-software-project-lifecycle.md)
 

--- a/process/non-software-lifecycle.md
+++ b/process/non-software-lifecycle.md
@@ -1,0 +1,3 @@
+# Non-software focused Project Life Cycle
+
+TBD

--- a/process/software-project-lifecycle.md
+++ b/process/software-project-lifecycle.md
@@ -1,10 +1,10 @@
 # Software focused Project Life Cycle
 
-Software focused projects are either directly under the governance of the Technical Advisory Committee (TAC) or a specific Working Group (WG). The progression of such a project lies accordingly within the TAC or the specific WG the project reports to (i.e., "the parent WG").
+Software focused projects are either directly under the governance of the Technical Advisory Committee (TAC) or a specific Working Group (WG). The TAC is responsible for reviewing and approving all significant changes to a Project's life cycle. Where a Project reports into a specific WG, that WG can support the Project's progression and provide recommendations to the TAC.
 
 Software focused projects follow the sandbox, incubating, graduated and archival lifecycle stagesdefined below.
 
-The lifecycle progression, movement from one stage to another, allows them to participate at the level that is most appropriate for them given where they are at.
+The lifecycle progression, movement from one stage to another, allows them to participate at the level that is most appropriate for them given where they are at, and signals to our community and those outside what level of maturity and continuity can be expected from a Project.
 
 <!-- TOC -->
 
@@ -46,7 +46,7 @@ The OpenSSF Sandbox is the entry point for early stage software projects and has
 * Encourage public visibility of experiments or other early work that can add value to the OpenSSF mission and build the ingredients of a successful Incubation level project
 * Facilitate alignment with existing Working Groups or Projects if (and only if) this is desired
 * Nurture projects (e.g. via OpenSSF Service Desk requests)
-* Remove possible legal and governance obstacles to adoption and contribution by ensuring all projects adhere to OpenSSF legal, code of conduct and IP Policy requirements.
+* Remove possible legal and governance obstacles to adoption and contribution by ensuring all projects adhere to OpenSSF legal, code of conduct, and IP Policy requirements.
 
 #### Gives - Review and Reporting
 *** Need Text ***
@@ -67,7 +67,7 @@ Sandbox projects should be early-stage projects that the OpenSSF TAC or parent W
 
 #### Project Graduation Process: Sandbox to Incubating
 
-Incubating software focused projects are required to undergo due diligence as a part of the process to move from Sandbox to Incubation. Due Diligence is driven by a TAC or parent WG sponsor, with two weeks for public comment before a vote is called.
+Incubating software focused projects are required to undergo due diligence as a part of the process to move from Sandbox to Incubation. Due Diligence is driven by a TAC or parent WG sponsor, with two weeks for public comment before a vote is called. Once the diligence is complete and the proposal made, two weeks are allocated for public comment before a TAC vote is called.
 
 #### Submission Forms for Sandbox
 
@@ -94,7 +94,7 @@ Incubating software focused projects are required to undergo due diligence as a 
 To be accepted to incubating stage, a project must meet the sandbox stage requirements plus:
 
 * Document that it is being used successfully in production by at least three independent end users which, in the TAC’s judgement, are of adequate quality and scope.
-* Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
+* Have a healthy number of maintainers. A maintainer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
 * Demonstrate a substantial ongoing flow of commits and merged contributions.
 * Since these metrics can vary significantly depending on the type, scope and size of a project, the TAC has final judgement over the level of activity that is adequate to meet these criteria
 * A clear versioning scheme.
@@ -103,10 +103,10 @@ To be accepted to incubating stage, a project must meet the sandbox stage requir
 #### Project Graduation Process: Incubating to Graduation
 
 Software focused projects that wish to move from Incubating to Graduation should open a PR confirming the following criteria:
-* Have committers from at least two organizations.
+* Have maintainers from at least two organizations.
 * Have achieved and maintained a [Core Infrastructure Initiative Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
-* Have completed an independent and third party security audit with results published of similar scope and quality as [this example](https://github.com/envoyproxy/envoy#security-audit) which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
-* Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
+* Have completed an independent and third party security audit with results published of similar scope and quality as [this example](https://github.com/envoyproxy/envoy#security-audit) which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation. The TAC, or another WG, may provide assistance in acquiring such an audit.
+* Explicitly define a project governance and process to be granted maintainership within the project team. This is preferably laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus maintainers.
 * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
 * Please include a short one-page narrative based off the Graduation template, no more than 500 words.
 

--- a/process/software-project-lifecycle.md
+++ b/process/software-project-lifecycle.md
@@ -1,0 +1,161 @@
+# Software focused Project Life Cycle
+
+Software focused projects are either directly under the governance of the Technical Advisory Committee (TAC) or a specific Working Group (WG). The progression of such a project lies accordingly within the TAC or the specific WG the project reports to (i.e., "the parent WG").
+
+Software focused projects follow the sandbox, incubating, graduated and archival lifecycle stagesdefined below.
+
+The lifecycle progression, movement from one stage to another, allows them to participate at the level that is most appropriate for them given where they are at.
+
+<!-- TOC -->
+
+  - [Stages - Definitions & Expectations](#stages---definitions--expectations)
+      - [Sandbox](#sandbox)
+          - [Gives - Review and Reporting](#gives---review-and-reporting)
+          - [Gets - Benefits](#gets---benefits)
+          - [Sandbox Entry Requirements](#sandbox-entry-requirements)
+          - [Project Graduation Process: Sandbox to Incubating](#project-graduation-process-sandbox-to-incubating)
+          - [Submission Forms for Sandbox](#submission-forms-for-sandbox)
+          - [Submission Forms for Sandbox to Incubating](#submission-forms-for-sandbox-to-incubating)
+      - [Incubating](#incubating)
+          - [Gives - Review and Reporting](#gives---review-and-reporting)
+          - [Gets - Benefits](#gets---benefits)
+          - [Incubating Entry Requirements](#incubating-entry-requirements)
+          - [Project Graduation Process: Incubating to Graduation](#project-graduation-process-incubating-to-graduation)
+          - [Submission Forms for Incubating](#submission-forms-for-incubating)
+          - [Submission Forms for Incubating to Graduation](#submission-forms-for-incubating-to-graduation)
+      - [Graduated](#graduated)
+          - [Gives - Review and Reporting](#gives---review-and-reporting)
+          - [Gets - Benefits](#gets---benefits)
+          - [Project Graduation Process: Graduated to Archiving](#project-graduation-process-graduated-to-archiving)
+          - [Submission Forms for Graduated to Archived](#submission-forms-for-graduated-to-archived)
+      - [Archived](#archived)
+
+<!-- /TOC -->
+
+
+## Stages - Definitions & Expectations
+
+Software focused projects have a maturity level of sandbox, incubating, or graduated. Archived is for such projects no longer in active development. The maturity level is a signal by OpenSSF as to what sorts of enterprises should be adopting different projects. Software focused projects increase their maturity by demonstrating their sustainability to OpenSSF’s Technical Advisory Committee(TAC): that they have adoption, a healthy rate of changes, committers from multiple organizations, have adopted the OpenSSF Code of Conduct, and have achieved and maintained the Core Infrastructure Initiative Best Practices Badge.
+
+![Project Stages](/process/project-stages.png)
+
+### Sandbox
+
+The OpenSSF Sandbox is the entry point for early stage software projects and has four goals:
+
+* Encourage public visibility of experiments or other early work that can add value to the OpenSSF mission and build the ingredients of a successful Incubation level project
+* Facilitate alignment with existing Working Groups or Projects if (and only if) this is desired
+* Nurture projects (e.g. via OpenSSF Service Desk requests)
+* Remove possible legal and governance obstacles to adoption and contribution by ensuring all projects adhere to OpenSSF legal, code of conduct and IP Policy requirements.
+
+#### Gives - Review and Reporting
+*** Need Text ***
+
+#### Gets - Benefits
+*** Need Text ***
+
+#### Sandbox Entry Requirements
+
+Software focused projects being submitted to the OpenSSF at the sandbox level are intended to be the entry point for early stage projects and are not required to undergo due diligence.
+
+Sandbox projects should be early-stage projects that the OpenSSF TAC or parent Working Group believes warrant experimentation.
+
+* New software focused projects that are designed to extend one or more OpenSSF Projects with functionality or interoperability libraries.
+* Independent software focused projects that fit the OpenSSF mission and provide potential for a novel approach to existing functional areas (or are an attempt to meet an unfulfilled need)
+* Software focused projects commissioned or sanctioned by the OpenSSF, including initial code for OpenSSF WG collaborations, and "experimental" projects
+* Any software focused project that realistically intends to join OpenSSF Incubation in future and wishes to lay the foundations for that.
+
+#### Project Graduation Process: Sandbox to Incubating
+
+Incubating software focused projects are required to undergo due diligence as a part of the process to move from Sandbox to Incubation. Due Diligence is driven by a TAC or parent WG sponsor, with two weeks for public comment before a vote is called.
+
+#### Submission Forms for Sandbox
+
+1. [Proposal](TBD)
+2. [Legal](TBD)
+
+#### Submission Forms for Sandbox to Incubating
+
+1. [Proposal](TBD)
+2. [Legal](TBD)
+
+### Incubating
+
+![Incubating](/process/incubation-process.png)
+
+#### Gives - Review and Reporting
+*** Need Text ***
+
+#### Gets - Benefits
+*** Need Text ***
+
+#### Incubating Entry Requirements
+
+To be accepted to incubating stage, a project must meet the sandbox stage requirements plus:
+
+* Document that it is being used successfully in production by at least three independent end users which, in the TAC’s judgement, are of adequate quality and scope.
+* Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
+* Demonstrate a substantial ongoing flow of commits and merged contributions.
+* Since these metrics can vary significantly depending on the type, scope and size of a project, the TAC has final judgement over the level of activity that is adequate to meet these criteria
+* A clear versioning scheme.
+* Specifications must have at least one public reference implementation.
+
+#### Project Graduation Process: Incubating to Graduation
+
+Software focused projects that wish to move from Incubating to Graduation should open a PR confirming the following criteria:
+* Have committers from at least two organizations.
+* Have achieved and maintained a [Core Infrastructure Initiative Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
+* Have completed an independent and third party security audit with results published of similar scope and quality as [this example](https://github.com/envoyproxy/envoy#security-audit) which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
+* Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
+* Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
+* Please include a short one-page narrative based off the Graduation template, no more than 500 words.
+
+#### Submission Forms for Incubating
+
+1. [Proposal](TBD)
+2. [Legal](TBD)
+
+#### Submission Forms for Incubating to Graduation
+
+1. [Proposal](TBD)
+2. [Legal](TBD)
+
+### Graduated
+
+Graduated projects signal the highest level of maturity for an OpenSSF project.
+
+#### Gives - Review and Reporting
+*** Need Text ***
+
+#### Gets - Benefits
+*** Need Text ***
+
+#### Project Graduation Process: Graduated to Archiving
+
+Open source projects have a lifecycle and there are times that projects become inactive due to a variety of reasons. There are also cases where a project may no longer want to be supported by the TAC or the parent WG, or the TAC or parent WG may no longer wish to recommend the use of a project.
+
+#### Archiving Criteria
+
+When voting on a proposal to archive a project, the TAC or parent WG members may wish to consider whether the project continues to meet the criteria for OpenSSF acceptance. The TAC or parent WG may also look at activity levels in the project (https://all.devstats.cncf.io/d/53/projects-health-table?orgId=1), although it is important to note that there is a difference between a mature project that doesn't get much attention any more but is stable, versus a project that is inactive.
+
+#### Submission Forms for Graduated to Archived
+
+1. [Proposal](TBD)
+2. [Legal](TBD)
+
+### Archived
+
+Archived projects are no longer in active development and are only archived after a TAC or parent WG vote.
+
+What does archiving for an OpenSSF software focused project mean?
+* OpenSSF will no longer provide support for the project via service desk
+* OpenSSF will list archived projects online
+* Trademarks and domain names of archived projects are still hosted by the OpenSSF and the Linux Foundation
+* OpenSSF can provide services such as documentation updates to help transition users.
+* Other OpenSSF marketing activities will no longer be provided for the project
+
+To archive a project:
+* A proposal must be put forth to the TAC or WG repo
+* The TAC or parent WG will inform the project maintainers, OpenSSF end user community and wider community of all archiving proposals
+* The proposal must remain open for at least 2 weeks of discussion after the maintainers are informed.
+* A vote must be finalized with 2/3 approval from the TAC or parent WG.

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -37,7 +37,7 @@ progress a project will move to `End-of-Life`. The details for each phase follow
 
 * Operate as part of the OpenSSF adhering to community policies
 * Deliver quarterly reviews to TAC
-* Complete and request TAC approval of [README.md](https://github.com/ossf/project-template/blob/main/README.md)
+* Complete and request TAC approval of [README.md](https://github.com/ossf/project-template/blob/main/README.md) which defines the WG's Charter and lists primary point(s) of contact from the TAC to the WG (this is often the WG Chair).
 * Meet on a regular cadence. Meetings are public, recorded, and on the calendar
 * Have access to community resources (Zooms, YouTube channels, GitHub, Slack channels, etc.)
 * Can request funding/other resources (subject to TAC/GB approval)
@@ -52,6 +52,10 @@ progress a project will move to `End-of-Life`. The details for each phase follow
 * Have at least 5 regular members from at least 3 different organizations attending regularly as
 recorded in meeting minutes.
 * Request TAC approval. TAC will vote to approve or provide constructive guidance
+
+## To remain `Active`:
+
+A WG is expected to continue operating per the above guidelines, and to provide the TAC with quarterly status updates, and to approach the TAC when seeking approval of substantial changes (such as when accepting or promoting new Projects).
 
 ## Once `Active`:
 

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -1,19 +1,21 @@
-# Working Group Life Cycle
+# Working Group (WG) Life Cycle
 
-Contributors interested in starting a new working group are encouraged to first review the existing
-working groups and projects. It is very likely that an existing working group could be extended to
+Working Groups are under the governance of the Technical Advisory Committee (TAC).
+
+Contributors interested in starting a new WG are encouraged to first review the existing
+WGs and projects. It is very likely that an existing WG could be extended to
 cover the new topic. If this is the case, please bring your time and energy into that existing working
 group. Your contributions are very welcome!
 
-However, if no existing effort covers the topic feel free to make use of the existing working group
-meetings, mailing lists, and/or Slack channels to solicit support for a new working group.
+However, if no existing effort covers the topic feel free to make use of the existing WG
+meetings, mailing lists, and/or Slack channels to solicit support for a new WG.
 
-Please note that running a working group successfully requires an extended effort.
+Please note that running a WG successfully requires an extended effort.
 Be prepared to commit at least several hours per week for a year or more.
 
-The Working Group Life Cycle begins with establishing commitments from other interested
-contributors then making a proposal to the Technical Advisory Committee (TAC). If accepted, the
-Working Group will begin as `Incubating`. This is a boot strapping phase for the group to adopt
+The WG Life Cycle begins with establishing commitments from other interested
+contributors then making a proposal to the TAC. If accepted, the
+WG will begin as `Incubating`. This is a boot strapping phase for the group to adopt
 OpenSSF community policies and norms. Once those are met the group becomes `Active` and will be
 fully recognized in OpenSSF. Either upon completing its objectives or no longer making forward
 progress a project will move to `End-of-Life`. The details for each phase follow.
@@ -35,17 +37,17 @@ progress a project will move to `End-of-Life`. The details for each phase follow
 
 * Operate as part of the OpenSSF adhering to community policies
 * Deliver quarterly reviews to TAC
-* Complete and request TAC approval of [readme.md](https://github.com/ossf/project-template/blob/main/README.md)
+* Complete and request TAC approval of [README.md](https://github.com/ossf/project-template/blob/main/README.md)
 * Meet on a regular cadence. Meetings are public, recorded, and on the calendar
 * Have access to community resources (Zooms, YouTube channels, GitHub, Slack channels, etc.)
 * Can request funding/other resources (subject to TAC/GB approval)
     * NOTE: _At the time of this draft, funding and resources beyond collaboration tools have not
-    been established in the OpenSSF. Working groups should expect that their main resource is the
+    been established in the OpenSSF. WGs should expect that their main resource is the
     community contributions they are able to recruit._
 
 ## To become `Active`:
 
-* Have received TAC approval of the readme.md per `Incubating` requirements above
+* Have received TAC approval of the README.md per `Incubating` requirements above
 * Have met at least 4 times over a period of at least 2 months since becoming `Incubating`
 * Have at least 5 regular members from at least 3 different organizations attending regularly as
 recorded in meeting minutes.
@@ -59,10 +61,10 @@ recorded in meeting minutes.
 ## To become `End-of-Life`:
 
 * Work has stopped
-    * The Working Group has completed its chartered deliverables
+    * The WG has completed its chartered deliverables
     or
-    * The Working Group is no longer progressing on its deliverables as determined by the TAC
-* In either case the TAC will vote to formally end the Working Group
+    * The WG is no longer progressing on its deliverables as determined by the TAC
+* In either case the TAC will vote to formally end the WG.
 
 ## Once `End-of-Life`:
 


### PR DESCRIPTION
This is a different take on the separation of WGs and Projects which tries to stick to the reality OpenSSF finds itself in and where we have many initiatives called "projects" that are not software focused.

This approach leverages the existing WG lifecycle and leverages the new lifecycle
inherited from CNCF for software focused projects while introducing a new
yet-to-be-defined lifecycle for non-software focused projects.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

IMPORTANT NOTE: This PR is an alternative to PR #95. Only one of them should be merged.

Additional Note: If adopted, this approach should be followed by an update of the OpenSSF charter to match this model.