### PR TITLE
Create resource request documentation

### DIFF
--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -16,6 +16,7 @@ All OpenSSF projects receive support and resources from the Foundation. The type
 To post on the OpenSSF blog, projects should contact the OpenSSF Marketing Committee with a blog draft two weeks before the requested publication date. The Committee does their best to accommodate requested publication dates, but projects should plan to be flexible during high-traffic times (e.g. events). Posts and timing is at the editorial discretion of the Marketing Committee; posts must follow the Code of Conduct, be relevant to the OpenSSF mission, and not promote vendor or commercial products. 
 
 To receive space in an OpenSSF newsletter, projects should contact the Marketing Committee a minimum of two weeks before the newsletter publication date. Projects are responsible for tracking due dates and submitting materials.
+Technical content should be reviewed by the TAC, and potentially other WG's or Committees as appropriate. This includes, but is not limited to: white papers, technical briefings, policy recommendations, etc. This does not include project-specific announcements, such as those relating to project milestone releases. 
 
 ### Contributor meet ups at OpenSSF events
 

--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -9,7 +9,7 @@ All OpenSSF projects receive support and resources from the Foundation. The type
     - [Security audits](#security-audits-and-improvements)
     - [Code of Conduct support](#code-of-conduct-support)
 
-## Requests through the OpenSSF Marketing WG
+## Requests through the OpenSSF Marketing Committee
 
 ### Communications and content
 

--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -13,7 +13,7 @@ All OpenSSF projects receive support and resources from the Foundation. The type
 
 ### Communications and content
 
-To post on the OpenSSF blog, projects should contact the OpenSSF Marketing WG with a blog draft two weeks before the requested publication date. The WG does their best to accomodate requested publication dates, but projects should plan to be flexible during high-traffic times (e.g. events). Posts and timing is at the editorial discretion of the Marketing WG; posts must follow the Code of Conduct, be relevant to the OpenSSF mission, and not promote vendor or commercial products. 
+To post on the OpenSSF blog, projects should contact the OpenSSF Marketing Committee with a blog draft two weeks before the requested publication date. The Committee does their best to accommodate requested publication dates, but projects should plan to be flexible during high-traffic times (e.g. events). Posts and timing is at the editorial discretion of the Marketing Committee; posts must follow the Code of Conduct, be relevant to the OpenSSF mission, and not promote vendor or commercial products. 
 
 To receive space in an OpenSSF newsletter, projects should contact the Marketing WG a minimum of two weeks before the newsletter publication date. Projects are responsible for tracking due dates and submitting materials. 
 

--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -19,7 +19,7 @@ To receive space in an OpenSSF newsletter, projects should contact the Marketing
 
 ### Contributor meet ups at OpenSSF events
 
-Projects that would like contributor meet up space at OpenSSF events should contact the OpenSSF Marketing WG with a request six months before the event date. Late requests may be accomodated but are not guaranteed. The events team handles room reservations, attendee registration if necessary, and connect the project to relevant event space groups like A/V. Projects are responsible for organizing and running their contributor meet up.
+Projects that would like contributor meet up space at OpenSSF events should contact the OpenSSF Marketing Committee with a request six months before the event date, or as soon as the event is announced if it is less than six months. Late requests may be accommodated but are not guaranteed. The events team handles room reservations, attendee registration if necessary, and connecting the project leads to event and facility support staff. Projects are responsible for organizing and running their own contributor meet up.
 
 ### Swag
 

--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -40,7 +40,7 @@ Limited, time-bound maintainer stipends for specified project improvements may b
 
 ### Security audits and improvements
 
-Qualifying projects may request funding for security audits and other services offered by third party security professionals. Before creating a request for proposals, projects should confirm funding availablity with the OpenSSF Budget Committee. After receiving proposals, projects should request their selected proposal be funded through the Budget Committee. Projects who need assistance creating an RFP should contact the OpenSSF GB Planning Committee. RFPs must be posted in a public channel(s) (GitHub issue, mailing list). OpenSSF member companies may bid on RFPs. 
+Qualifying projects may request funding for security audits and other services offered by third party security professionals. Before creating a request for proposals, projects should confirm funding availability with the OpenSSF Budget Committee. After receiving proposals, projects should request their selected proposal be funded through the Budget Committee. Projects who need assistance creating an RFP should contact the OpenSSF Planning Committee. RFPs must be posted in a public channel(s) (GitHub issue, mailing list). OpenSSF member companies may bid on RFPs. 
 
 ## Other
 

--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -15,7 +15,7 @@ All OpenSSF projects receive support and resources from the Foundation. The type
 
 To post on the OpenSSF blog, projects should contact the OpenSSF Marketing Committee with a blog draft two weeks before the requested publication date. The Committee does their best to accommodate requested publication dates, but projects should plan to be flexible during high-traffic times (e.g. events). Posts and timing is at the editorial discretion of the Marketing Committee; posts must follow the Code of Conduct, be relevant to the OpenSSF mission, and not promote vendor or commercial products. 
 
-To receive space in an OpenSSF newsletter, projects should contact the Marketing WG a minimum of two weeks before the newsletter publication date. Projects are responsible for tracking due dates and submitting materials. 
+To receive space in an OpenSSF newsletter, projects should contact the Marketing Committee a minimum of two weeks before the newsletter publication date. Projects are responsible for tracking due dates and submitting materials.
 
 ### Contributor meet ups at OpenSSF events
 

--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -1,0 +1,57 @@
+# Requesting Resources
+
+All OpenSSF projects receive support and resources from the Foundation. The type of resources and amount vary by project stage; refer to the [project lifecycles](process/project_lifecycle.md) for details. 
+
+- Common requests
+    - [Blogs](#communications-and-content)
+    - [Event space](#contribuor-meet-ups-at-OpenSSF-events)
+    - [Infrastructure](#infrastructure)
+    - [Security audits](#security-audits-and-improvements)
+    - [Code of Conduct support](#code-of-conduct-support)
+
+## Requests through the OpenSSF Marketing WG
+
+### Communications and content
+
+To post on the OpenSSF blog, projects should contact the OpenSSF Marketing WG with a blog draft two weeks before the requested publication date. The WG does their best to accomodate requested publication dates, but projects should plan to be flexible during high-traffic times (e.g. events). Posts and timing is at the editorial discretion of the Marketing WG; posts must follow the Code of Conduct, be relevant to the OpenSSF mission, and not promote vendor or commercial products. 
+
+To receive space in an OpenSSF newsletter, projects should contact the Marketing WG a minimum of two weeks before the newsletter publication date. Projects are responsible for tracking due dates and submitting materials. 
+
+### Contributor meet ups at OpenSSF events
+
+Projects that would like contributor meet up space at OpenSSF events should contact the OpenSSF Marketing WG with a request six months before the event date. Late requests may be accomodated but are not guaranteed. The events team handles room reservations, attendee registration if necessary, and connect the project to relevant event space groups like A/V. Projects are responsible for organizing and running their contributor meet up.
+
+### Swag
+
+The OpenSSF Marketing Committee keeps a small, annual swag stipend for all projects. Projects may wish to seek outside funding for project swag beyond this stipend.
+
+## Requests through the OpenSSF Budget Committee
+Requests that go through the OpenSSF Budget Committee are reviewed at regularly occuring Budget Committee meetings. Projects should plan their funding needs and requests with this timeline in mind.
+
+### Infrastructure
+
+_Program TBD as of June 2022. Intended program details below._
+Central infrastructure is available to qualifying projects for test and build support. Projects should submit requests on an annual basis to the OpenSSF Budget Committee, a minimum of three months before the requested start date. Projects are responsible for submitting a resource forecast with their request. The Budget Committee and project will work together to agree on minimum infrastructure support based on annual budget. Projects are responsible for communicating to the Budget Committee if there are anticipated increases (including spike events) arise. 
+
+### Maintainer stipends
+
+_Program TBD as of June 2022. Intended program details below._
+Limited, time-bound maintainer stipends for specified project improvements may be available to qualifying projects. Projects should submit a request to the OpenSSF Budget Committee with proposed scope, cost, desired outcome, TAC sponsor approval, and timeline at least three months before the requested start date. Maintainer stipends may not be paid to employees of OpenSSF member companies (excludes Associate members).
+
+### Security audits and improvements
+
+Qualifying projects may request funding for security audits and other services offered by third party security professionals. Before creating a request for proposals, projects should confirm funding availablity with the OpenSSF Budget Committee. After receiving proposals, projects should request their selected proposal be funded through the Budget Committee. Projects who need assistance creating an RFP should contact the OpenSSF GB Planning Committee. RFPs must be posted in a public channel(s) (GitHub issue, mailing list). OpenSSF member companies may bid on RFPs. 
+
+## Other
+
+### Code of Conduct support
+
+All projects must follow the [OpenSSF Code of Conduct](https://openssf.org/community/code-of-conduct/). If projects receive reports of conduct violations, they should report them to conduct@openssf.org.
+
+### Vulnerability disclosure assistance
+
+Qualifying projects may request assistance with coordinated disclosure from the Vulnerability Disclosure Working Group. **This assistance is restricted to understanding the disclosure process and workflow steps** and troubleshooting common coordination scenarios such as, "The researcher has not responded, how do I proceed?" Vulnerability details should not to be shared in this forum. Projects may request assistance by contacting the Vuln Disclosure WG Chair. 
+
+### Additional requests
+
+Qualifying projects may raise funds for additional projects. Projects should present a fundraising objective, targeted amount, desired outcomes and milestones for approval by the TAC. With TAC approval, OpenSSF staff will assist projects in setting up and coordinating collecting additional funds. 

--- a/process/request_resources.md
+++ b/process/request_resources.md
@@ -47,7 +47,9 @@ Qualifying projects may request funding for security audits and other services o
 
 ### Code of Conduct support
 
-All projects must follow the [OpenSSF Code of Conduct](https://openssf.org/community/code-of-conduct/). If projects receive reports of conduct violations, they should report them to conduct@openssf.org.
+All projects must follow the [OpenSSF Code of Conduct](https://openssf.org/community/code-of-conduct/), or, if a project has its own Code of Conduct, it must be reviewed and approved by the TAC. 
+
+If projects receive reports of conduct violations, they should report them to conduct@openssf.org.
 
 ### Vulnerability disclosure assistance
 


### PR DESCRIPTION
Initial draft: Documents how OpenSSF projects can request the resources/benefits outlined in the Project Lifecycle document. cc @AevaOnline for review and input.

- [ ] @strawberry-baked-alaska Please review section on when to engage Marketing Committee
- [ ] @david-a-wheeler @brianbehlendorf Please see section on infrastructure. Many ways this could be structured, but I imagine it's similar to the CNCF Cloud Credits program wants to do (cc @caniszczyk)

Re: Budget Committee requests, projects and members will need to be able to see a calendar of meetings, members and agenda etc to submit requests