### PR TITLE
Fixing link to OpenSSF Charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Meetings are also recorded and posted to the [OpenSSF YouTube channel](https://w
 
 ## Charter
 
-The TAC is chartered as part of the [Open Source Security Foundation Charter](https://github.com/ossf/foundation/blob/main/CHARTER.md).
+The TAC is chartered as part of the [Open Source Security Foundation Charter](https://openssf.org/about/charter/).
 
 ## Technical Initiatives
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Meetings are also recorded and posted to the [OpenSSF YouTube channel](https://w
 
 ## Charter
 
-The TAC is chartered as part of the [Open Source Security Foundation Charter](https://github.com/ossf/foundation/blob/main/Review%20Copy%20Only%20-%20Not%20for%20Execution_OpenSSF%20Participation%20Agreement%20and%20Charter%20(rev.%202020%2009%2011).pdf).
+The TAC is chartered as part of the [Open Source Security Foundation Charter](https://github.com/ossf/foundation/blob/main/CHARTER.md).
 
 ## Technical Initiatives
 


### PR DESCRIPTION
The link to the OpenSSF technical charter in the README is broken. This
changes the link to point to the new markdown version of the charter in
the foundation repository.

Signed-off-by: Georg Kunz <georg.kunz@ericsson.com>