### PR TITLE
fix link to charter PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Meetings are also recorded and posted to the [OpenSSF YouTube channel](https://w
 
 ## Charter
 
-The TAC is chartered as part of the [Open Source Security Foundation Charter](https://github.com/ossf/foundation/blob/main/Review%20Copy%20Only%20-%20Not%20for%20Execution_OpenSSF%20Participation%20Agreement%20and%20Charter%20(rev.%202020%2009%2011).pdf).
+The TAC is chartered as part of the [Open Source Security Foundation Charter](https://cdn.platform.linuxfoundation.org/agreements/openssf.pdf).
 
 ## Technical Initiatives
 


### PR DESCRIPTION
The charter PDF link was previously broken - fixing it to a working link.

Signed-off-by: Bob Callaway <bcallaway@google.com>