### PR TITLE
Editorial changes to the org terms and definitions

### DIFF
--- a/organizational-structure-overview.md
+++ b/organizational-structure-overview.md
@@ -11,33 +11,34 @@ The OpenSSF is comprised of instances of the following categories of official gr
 
 - The **Governing Board** (GB) oversees the budget and legal status/structure of the OpenSSF. Board meetings may or may not be open to the public.
 - **Committees** are formed by, and report to, the Board. Broadly speaking, Committees handle non-technical matters as needed by the GB, wherein a named set of people are tasked with handling a specific objective. Like the Board meetings, Committee meetings may or may not be open to the public.
-- The **Technical Advisory Council** (TAC) is responsible for the general success of all Technical Initiatives (defined below). TAC meetings are generally open to the public, with the exception of special sessions. 
-- **Technical Initiatives** are groups formed in support of the overall mission of the OpenSSF. Technical Initiatives include Working Groups (WG), Special Interest Groups (SIG), Projects, and services governed by their own Charters with various objectives, reporting relationships, and funding models described below.
+- The **Technical Advisory Council** (TAC) is responsible for the general success of all Technical Initiatives (defined below). TAC meetings are generally open to the public, with the exception of special sessions.
+- **Technical Initiatives** are groups formed in support of the overall mission of the OpenSSF. Technical Initiatives include Working Groups (WG), Special Interest Groups (SIG), Projects, and Services governed by their own Charters with various objectives, reporting relationships, and funding models described below.
    - All Technical Initiatives are open groups focused on a technical objective, with transparent proceedings that are open to the public, and vary in their objectives.
    - Technical Initiatives usually manage one or more GitHub repos of their own and may have separate meetings.
+- **Working Groups** (WG) are the primary organizational element of Technical Initiatives within the OpenSSF. Working Groups focus on developing deliverables such as guides, specifications, and educational material, or conducting initiatives such as an education outreach.
+   - While a WG does not produce open source software as a primary artifact, it may oversee Projects that do.
+   - A WG may also launch Special Interest Groups (SIG) to perform specific tasks other than creating software.
+   - WGs often include some open source code, or use licensed software, in fulfilment of their Charter.
 - A **Project** is a Technical Initiative focused on the development and ongoing support of open source licensed software (source code) and its supporting artifacts (technical documentation, etc.).
-- A **Working Group** (WG) focuses on developing other types of deliverables than software such as guides, specifications, and educational material, or conducting initiatives such as an education outreach. While a WG does not produce open source software as a primary artifact it may launch Projects that do so. A WG may also launch Special Interest Groups (SIG) to perform specific tasks. WGs often include some open source code, or use licensed software, in fulfilment of their Charter.
-- **Special Interest Groups** (SIG) are under the direct governance of their reporting WGs and are bound to achieving a very specific goal. 
-- A **Technical Deliverable** can be an open source licensed software and its supporting artifacts, a specification, or a technical guide. This is a technical artifact produced by a Technical Initiative.
-- A **Service** is a Technical Initiative in which software is either built or acquired to support or automate OSSF transactions.
+- **Special Interest Groups** (SIG) are under the direct governance of their reporting WGs and are bound to achieving a very specific and terminable goal.
+- A **Technical Deliverable** is any technical content produced by a Technical Initiative, such as open source licensed software, a specification, or a technical guide.
+   - Each **Project** shall have a Technical Deliverable including open source licensed software; this is what defines a Project as distinct from other Technical Initiatives such as SIGs.
+   - A **Service** is a publicly-run instance of software as a service, and is another form of Technical Deliverable distinct from the release of open source licensed software. This may be an operational output of a Technical Initiative in which software is either built or acquired to support or automate OSSF transactions.
 
 The following table describes the main types of groups and their characteristics.
 
 | Initiative | Expected lifespan | Primary output| Reporting relationship |	Economic model
 |------------|-------------------|---------------|------------------------|---------------
 | Working Group (WG) | unbounded | not software | to the TAC | normative
-| WG w/ SIF | unbounded | not software | to the TAC | special fund
 | Project |	unbounded | software | either TAC or WG | normative
-| Project w/ SIF | unbounded | software (or service) | to the TAC | special fund
 | Special Interest Group (WG) | bounded | not software | to a WG | normative
 
-SIF = Specific Initiative Fund
 
 ### TODO
 
-* define **SIF** 
-* define **Contributors**
-* criteria for approving or disapproving a Charter (if not already here)
+* define and document the governance relationships for Alpha/Omega, GNU Toolchain Initiative, and SigStore (collectively, "SIFs")
+* define **Contributors** in a consistent way, so that electorate membership can be consistently, and ideally procedurally, determined
+* define criteria for approving or disapproving the Charters of TAC-subordinate bodies
 
 ## Organizational Chart
 
@@ -76,12 +77,4 @@ flowchart TB
     B ====> subWG
 
     B ----> P1[Example Project]
-
-    subgraph subSIF[Special Initiative Funds]
-        ss[sigstore]
-        ao[Alpha-Omega]
-        gti[GNU Toolchain Infra]
-    end
-    B ==technical oversight==> subSIF
-    A --budgetary oversight--> subSIF
 ```


### PR DESCRIPTION
This change incorporates several discussions around the terminology
for use within the OpenSSF TAC Governance, and re-orders the items
to make it more readable.

Notably, this:
- clarify relationships between Technical Initiatives and Technical
  Deliverables
- clarify SIGs, incorporating "and terminable" from GH discussion
- clarify that Projects have 'open source software' as a deliverable
- clarify definition of a "Service"
- removes SIF (duplicating PR #119, to avoid merge conflict)

Signed-off-by: Aeva Black <806320+AevaOnline@users.noreply.github.com>