### PR TITLE
Update technical vision for OpenSSF

### DIFF
--- a/technical-vision.md
+++ b/technical-vision.md
@@ -1,4 +1,4 @@
-# OpenSSF Technical Vision
+# OpenSSF Technical Vision (v1), left for reference
 
 We envision a future where participants in the open source ecosystem use and share high quality software, with security handled proactively, by default, and as a matter of course:
 - Developers can easily learn secure development practices and are proactively guided by their tools to apply those practices and automatically informed when action is needed to prevent, remediate, or mitigate security issues.
@@ -7,3 +7,31 @@ We envision a future where participants in the open source ecosystem use and sha
 - Community members can provide information and notifications about product defects, mitigations, quality, and supportability and have this information rapidly flow forward across the ecosystem system to all users, and users can rapidly update their software or implement mitigations as appropriate.
 
 The Open Source Security Foundation (OpenSSF) provides tools, services, training, infrastructure, and resources to achieve this vision.
+
+# OpenSSF Technical Vision (v2 proposed)
+
+An aspirational view of the future we seek to create in 2-5 years:
+
+- OpenSSF is a well-respected strategic partner to both large OSS foundations and individual OSS projects
+    - Clearly positioned within ecosystem with a clear charter
+    - Catalyst for change and improving “secure by default”
+    - Trusted voice to consumers, producers, and market
+- Regardless of (programming language, VCS, CI platform, etc), consumers of OSS can rely on clear & consistent trusted signals of:
+    - Provenance of source code & artifacts
+    - Security posture of projects and artifacts
+    - Community health
+    - Maintainer intent (e.g. project archived, not responsive to PRs, etc)
+    - Consumer demand
+    - ...
+- Producers of OSS (at all levels of skill) have access to:
+    - Best practices guides, education, etc
+    - Extremely low-friction tooling to make security processes less onerous, more accurate, and trusted (burden of maintenance offloaded through opt-in automation)
+    - Ability to start new projects from a more secure default position
+    - ...
+- OpenSSF is an influential advocate of efforts that are aligned with OpenSSF's mission
+    - Meaningful, actionable standards (e.g. SBOM formats?)
+    - Interests and motivations of all parties are respected
+    - Catalyze improvements / action
+    - Ensure sufficient staffing, auditing, pen testing, rigor
+    - Multi-factor authentication
+    - ...

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -15,7 +15,7 @@ The Open Source Security Foundation (OpenSSF) provides tools, services, training
 
 - **Openness and Transparency**: We commit to encouraging all interested stakeholders to participate in the foundation and its working groups. The foundation’s work will be made publicly available.
 
-- **Maintainers** First: We approach the work of contributing to improving the security of open source software with a strong respect for open source maintainers and developers, with an intent to create resources and tooling to help scale security improvements to benefit the open source ecosystem as a whole.
+- **Maintainers First**: We approach the work of contributing to improving the security of open source software with a strong respect for open source maintainers and developers, with an intent to create resources and tooling to help scale security improvements to benefit the open source ecosystem as a whole.
 
 - **Diversity, Inclusion, and Representation**: We work to actively invite and include people from a range of backgrounds, locations, identities, and perspectives, and promote a culture of mutual respect and inclusiveness as a requirement for participation
 

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -1,89 +1,26 @@
-# OpenSSF Technical Vision (v1), left for reference
-
-We envision a future where participants in the open source ecosystem use and share high quality software, with security handled proactively, by default, and as a matter of course:
-- Developers can easily learn secure development practices and are proactively guided by their tools to apply those practices and automatically informed when action is needed to prevent, remediate, or mitigate security issues.
-- Developers, auditors, and regulators can create and easily distribute security policies that are enforced through tooling and automation, providing continuous assurance of the results.
-- Developers and researchers can identify security issues (including unintentional vulnerabilities and malicious software) and have this information swiftly flow backwards through the supply chain to someone who can rapidly address the issue.
-- Community members can provide information and notifications about product defects, mitigations, quality, and supportability and have this information rapidly flow forward across the ecosystem system to all users, and users can rapidly update their software or implement mitigations as appropriate.
-
-The Open Source Security Foundation (OpenSSF) provides tools, services, training, infrastructure, and resources to achieve this vision.
-
----
-
-# OpenSSF Values (pulled from [https://openssf.org/about/values/](https://openssf.org/about/values/))
-- **Public good**: We believe the security of open source is a public good and as an industry we have an obligation to address it for the commonwealth of the community.
-
-- **Openness and Transparency**: We commit to encouraging all interested stakeholders to participate in the foundation and its working groups. The foundation’s work will be made publicly available.
-
-- **Maintainers First**: We approach the work of contributing to improving the security of open source software with a strong respect for open source maintainers and developers, with an intent to create resources and tooling to help scale security improvements to benefit the open source ecosystem as a whole.
-
-- **Diversity, Inclusion, and Representation**: We work to actively invite and include people from a range of backgrounds, locations, identities, and perspectives, and promote a culture of mutual respect and inclusiveness as a requirement for participation
-
-- **Agility and Delivery**: We work to deliver concrete and useful outputs and tools to help make open source more secure. We do so in a manner that enables us to learn from experience and experiment, and improve our outputs accordingly.
-
-- **Credit where credit is due**: We commit to a culture where people’s contributions are recognized and acknowledged fairly.
-
-- **Neutrality**: We don’t bias toward any ecosystem, vendor or platforms.
-
-- **Empathy**: We recognize and understand each other’s challenges, perspective and circumstances. We commit to a culture of listening and caring for multiple opinions.
-
-# OpenSSF Technical Vision (v2 proposed)
-
-> _Note: the bullet points that are included below in block quotes would not be included in the final version of the vision, but are listed for reference/discussion._
+# OpenSSF Technical Vision
 
 An aspirational view of the future we seek to create in 2-5 years:
 
-### OpenSSF is a well-respected strategic partner to both large OSS foundations and individual OSS projects
-- Clearly positioned within broader ecosystem with a clear charter
-- Catalyst for change and improving “secure by default”
-- Trusted voice to consumers, producers, and market
+### OpenSSF is a well-respected strategic partner to large OSS foundations and individual OSS projects
+- OpenSSF is clearly positioned within broader ecosystem with a clear, altruistic charter
+- Periodically review the value proposition of OpenSSF with key stakeholders
+  - Joint OKRs on shared execution, utilization of OpenSSF-managed tools & content
+  - Roadmap alignment: if overlap exists between OpenSSF and another stakeholder, either publicly document rationale OR create/document/execute a convergence plan
+- OpenSSF speaks with a trusted voice to consumers, producers, and the broader market
 
-> Approaches to achieve the above statement:
-> - (proposed) Update OpenSSF website to reflect updated positioning
-> - (proposed) Ensure we have specific segmentation strategies for targeted audiences
-> - (proposed) Regular TAC / GB interlock with other OSS foundations with regular feedback into (annual?) planning cycles
-> - (proposed) Content / marketing plan with measurements on reach and impact
-> - Alpha/Omega: how to position?
-> - Securing Software Repositories WG
-> - Operator or financial sponsor of common centralized services (e.g. OSS-SIRT, MFA help desk, OpenSSF office hours)
+### OpenSSF is an influential advocate for mutually-beneficial external efforts and an educator of policy decision makers
+- Support creation & use of meaningful, actionable standards (e.g. SBOM formats, MFA)
+- OpenSSF acts as a catalyst for change and improving “secure by default”
+- Advocacy may be statements of support, education material, and/or direct funding
 
-### OpenSSF is an influential advocate for efforts that are aligned with its mission
-- Support development and use of meaningful, actionable standards (e.g. SBOM formats, MFA?)
-- Catalyze improvements / action through targeted investment
-- ...
+### Consumers of OSS can leverage clear & consistent trusted signals to better understand the security profile of open source content
+- Including (but not exclusively) provenance of source code & artifacts, security posture of projects and artifacts, community health metrics, vulnerability information, and measures of consumer demand (e.g. criticality score)
+- Consumers of OSS quickly understand the maintainer’s intentions regarding not only the license but also the project’s security posture (e.g. project archived, accepting PRs, etc)
+- All consumers of OSS (including producers of OSS who consume dependencies) will have access to training, tooling, and security information to make educated choices as they interact with the open source ecosystem
 
-> Approaches to achieve the above statement:
-> - Oversees time-bound projects to advocate for specific outcomes, e.g.
->     - Great MFA distribution project
->     - Sponsor of audits (via OSTIF & others) for critical projects
-> - TAC endorsement of specific standards-track efforts, to be incorporated across other OpenSSF foundation workstreams
->     - Direct funding / staffing on tooling and adoption efforts (e.g. SPDX-Python)?
->     - _question_: would it make sense to mandate use of the standard within foundation-hosted projects?
-> - (proposed) Engagement across platforms where developers already are (meetups, conferences, StackOverflow, etc)
->     - _idea_: should OpenSSF hire dev-rel resources to staff this?
-
-### Consumers of OSS can leverage clear & consistent trusted signals to better understand the security profile of open source content:
-- Provenance of source code & artifacts
-- Security posture of projects and artifacts
-- Community health
-- Maintainer intent (e.g. project archived, not responsive to PRs, etc)
-- Consumer demand / criticality score(?)
-- ...
-
-> Approaches to achieve the above statement:
-> - OpenSSF hosts projects that produce these signals and/or make them trustworthy and actionable
->     - OpenSSF funds the adoption of its projects (via SOS)
-> - OpenSSF hosts working groups that provide guidance on how to make use these signals
-> - Badging programs for projects
-> - End Users WG
-
-### Producers of OSS (at all skill levels; also explicitly are consumers of OSS through dependencies) have access to:
-- Best practices guides, education, etc
-- Extremely low-friction tooling to make security processes less onerous, more accurate, and trusted (burden of maintenance offloaded through opt-in automation)
+### Producers of OSS (of all skill levels) have the ability to proactively and reactively address both existing and emergent security threats
+- Best practices guides & education materials that ensure both current and future OSS developers obtain & maintain sufficient secure development skills
+- Extremely low-friction, automated tooling to make security processes less onerous, more accurate, and trusted (burden of maintenance offloaded through opt-in automation)
 - Ability to start new projects from a more secure default position
-- Ensure sufficient staffing, auditing, pen testing, rigor for critical projects
-- ...
-
-> Approaches to achieve the above statement:
-> - OpenSSF hosts projects that produce tools that minimizes burden on project maintainers
-> - OpenSSF hosts working groups that publish & maintain recommendations on how to produce secure OSS, interface with consumers, etc
+- Ensure sufficient staffing, auditing, continuous testing, rigor for critical projects

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -29,6 +29,6 @@ An aspirational view of the future we seek to create in 2-5 years:
 
 ### Producers of OSS (of all skill levels) have the ability to proactively and reactively address both existing and emergent security threats
 - Best practices guides & education materials that ensure both current and future OSS developers obtain & maintain sufficient secure development skills
-- Extremely low-friction, automated tooling to make security processes less onerous, more accurate, and trusted (burden of maintenance offloaded through opt-in automation)
+- Extremely low-friction, automated tooling to make security processes less onerous, more accurate, and trusted (burden of maintenance offloaded through opt-in automation); these tools and improvements will be made available at zero cost
 - Ability to start new projects from a more secure default position
 - Ensure sufficient staffing, auditing, continuous testing, rigor for critical projects

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -7,11 +7,13 @@ An aspirational view of the future we seek to create in 2-5 years:
 - Periodically review the value proposition of OpenSSF with key stakeholders
   - Joint OKRs on shared execution, utilization of OpenSSF-managed tools & content
   - Roadmap alignment: if overlap exists between OpenSSF and another stakeholder, either publicly document rationale OR create/document/execute a convergence plan
-- OpenSSF speaks with a trusted voice to consumers, producers, and the broader market
+- OpenSSF speaks with a trusted voice to users, contributors, and the broader market
 
 ### OpenSSF is an influential advocate for mutually-beneficial external efforts and an educator of policy decision makers
 - Support creation & use of meaningful, actionable standards (e.g. SBOM formats, MFA)
-- OpenSSF acts as a catalyst for change and improving “secure by default”
+- OpenSSF advocates for various actors (including maintainers, contributors, and adopters) in the open source ecosystem to improve their default security posture, and catalyzes efforts to reduce or eliminate friction in achieving that state; for example (but not exclusively):
+  - SLSA ensures tampering and other security threats to the software supply chain of open source projects, groups, and communities are reduced and/or eliminated
+  - Memory Safety efforts that aim to eliminate entire classes of security threats through using memory safe programming languages
 - Advocacy may be statements of support, education material, and/or direct funding
 
 ### Consumers of OSS can leverage clear & consistent trusted signals to better understand the security profile of open source content

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -13,7 +13,7 @@ An aspirational view of the future we seek to create in 2-5 years:
 - Support creation & use of meaningful, actionable standards (e.g. SBOM formats, MFA)
 - OpenSSF advocates for various actors (including maintainers, contributors, and adopters) in the open source ecosystem to improve their default security posture, and catalyzes efforts to reduce or eliminate friction in achieving that state; for example (but not exclusively):
   - SLSA ensures tampering and other security threats to the software supply chain of open source projects, groups, and communities are reduced and/or eliminated
-  - Memory Safety efforts that aim to eliminate entire classes of security threats through using memory safe programming languages
+  - Memory Safety efforts that aim to eliminate entire classes of security threats through using memory safe programming languages where possible
 - Advocacy may be statements of support, education material, and/or direct funding
 
 ### Consumers of OSS can leverage clear & consistent trusted signals to better understand the security profile of open source content

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -25,7 +25,7 @@ An aspirational view of the future we seek to create in 2-5 years:
 ### Consumers of OSS can leverage clear & consistent trusted signals to better understand the security profile of open source content
 - Including (but not exclusively) provenance of source code & artifacts, security posture of projects and artifacts, community health metrics, vulnerability information, and measures of consumer demand (e.g. criticality score)
 - Consumers of OSS quickly understand the maintainer’s intentions regarding not only the license but also the project’s security posture (e.g. project archived, accepting PRs, etc)
-- All consumers of OSS (including producers of OSS who consume dependencies) will have access to training, tooling, and security information to make educated choices as they interact with the open source ecosystem
+- All consumers of OSS (including producers of OSS who consume dependencies) will have zero-cost access to training, tooling, and security information to make educated choices as they interact with the open source ecosystem
 
 ### Producers of OSS (of all skill levels) have the ability to proactively and reactively address both existing and emergent security threats
 - Best practices guides & education materials that ensure both current and future OSS developers obtain & maintain sufficient secure development skills

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -10,6 +10,23 @@ The Open Source Security Foundation (OpenSSF) provides tools, services, training
 
 ---
 
+# OpenSSF Values (pulled from [https://openssf.org/about/values/](https://openssf.org/about/values/))
+- **Public good**: We believe the security of open source is a public good and as an industry we have an obligation to address it for the commonwealth of the community.
+
+- **Openness and Transparency**: We commit to encouraging all interested stakeholders to participate in the foundation and its working groups. The foundation’s work will be made publicly available.
+
+- **Maintainers** First: We approach the work of contributing to improving the security of open source software with a strong respect for open source maintainers and developers, with an intent to create resources and tooling to help scale security improvements to benefit the open source ecosystem as a whole.
+
+- **Diversity, Inclusion, and Representation**: We work to actively invite and include people from a range of backgrounds, locations, identities, and perspectives, and promote a culture of mutual respect and inclusiveness as a requirement for participation
+
+- **Agility and Delivery**: We work to deliver concrete and useful outputs and tools to help make open source more secure. We do so in a manner that enables us to learn from experience and experiment, and improve our outputs accordingly.
+
+- **Credit where credit is due**: We commit to a culture where people’s contributions are recognized and acknowledged fairly.
+
+- **Neutrality**: We don’t bias toward any ecosystem, vendor or platforms.
+
+- **Empathy**: We recognize and understand each other’s challenges, perspective and circumstances. We commit to a culture of listening and caring for multiple opinions.
+
 # OpenSSF Technical Vision (v2 proposed)
 
 > _Note: the bullet points that are included below in block quotes would not be included in the final version of the vision, but are listed for reference/discussion._
@@ -45,7 +62,7 @@ An aspirational view of the future we seek to create in 2-5 years:
 > - (proposed) Engagement across platforms where developers already are (meetups, conferences, StackOverflow, etc)
 >     - _idea_: should OpenSSF hire dev-rel resources to staff this?
 
-### Regardless of (programming language, VCS, CI platform, etc), consumers of OSS can rely on clear & consistent trusted signals of:
+### Consumers of OSS can leverage clear & consistent trusted signals to better understand the security profile of open source content:
 - Provenance of source code & artifacts
 - Security posture of projects and artifacts
 - Community health

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -2,6 +2,12 @@
 
 An aspirational view of the future we seek to create in 2-5 years:
 
+## The OpenSSF is a trusted partner to affiliated open source foundations and projects, and provides valuable services to those projects and foundations.
+- The OpenSSF is well positioned within the broader ecosystem and has a clearly articulated charter which supports the activities of the broader community of open source practitioners
+- To maintain that trusted relationship, the OpenSSF's mission and value proposition is periodically reviewed with community representatives and constituents, as well as its funding Members
+- OpenSSF resources are responsibly managed and utilized towards this Vision in clear, consistent, transparent, and democratic ways.
+- Where overlap exists between the OpenSSF's mission and that of another organization, the OpenSSF strives to support other organizations through partnership first, and does not engage in "picking winners and losers".
+
 ### OpenSSF is a well-respected strategic partner to large OSS foundations and individual OSS projects
 - OpenSSF is clearly positioned within broader ecosystem with a clear, altruistic charter
 - Periodically review the value proposition of OpenSSF with key stakeholders

--- a/technical-vision.md
+++ b/technical-vision.md
@@ -8,30 +8,65 @@ We envision a future where participants in the open source ecosystem use and sha
 
 The Open Source Security Foundation (OpenSSF) provides tools, services, training, infrastructure, and resources to achieve this vision.
 
+---
+
 # OpenSSF Technical Vision (v2 proposed)
+
+> _Note: the bullet points that are included below in block quotes would not be included in the final version of the vision, but are listed for reference/discussion._
 
 An aspirational view of the future we seek to create in 2-5 years:
 
-- OpenSSF is a well-respected strategic partner to both large OSS foundations and individual OSS projects
-    - Clearly positioned within ecosystem with a clear charter
-    - Catalyst for change and improving “secure by default”
-    - Trusted voice to consumers, producers, and market
-- Regardless of (programming language, VCS, CI platform, etc), consumers of OSS can rely on clear & consistent trusted signals of:
-    - Provenance of source code & artifacts
-    - Security posture of projects and artifacts
-    - Community health
-    - Maintainer intent (e.g. project archived, not responsive to PRs, etc)
-    - Consumer demand
-    - ...
-- Producers of OSS (at all levels of skill) have access to:
-    - Best practices guides, education, etc
-    - Extremely low-friction tooling to make security processes less onerous, more accurate, and trusted (burden of maintenance offloaded through opt-in automation)
-    - Ability to start new projects from a more secure default position
-    - ...
-- OpenSSF is an influential advocate of efforts that are aligned with OpenSSF's mission
-    - Meaningful, actionable standards (e.g. SBOM formats?)
-    - Interests and motivations of all parties are respected
-    - Catalyze improvements / action
-    - Ensure sufficient staffing, auditing, pen testing, rigor
-    - Multi-factor authentication
-    - ...
+### OpenSSF is a well-respected strategic partner to both large OSS foundations and individual OSS projects
+- Clearly positioned within broader ecosystem with a clear charter
+- Catalyst for change and improving “secure by default”
+- Trusted voice to consumers, producers, and market
+
+> Approaches to achieve the above statement:
+> - (proposed) Update OpenSSF website to reflect updated positioning
+> - (proposed) Ensure we have specific segmentation strategies for targeted audiences
+> - (proposed) Regular TAC / GB interlock with other OSS foundations with regular feedback into (annual?) planning cycles
+> - (proposed) Content / marketing plan with measurements on reach and impact
+> - Alpha/Omega: how to position?
+> - Securing Software Repositories WG
+> - Operator or financial sponsor of common centralized services (e.g. OSS-SIRT, MFA help desk, OpenSSF office hours)
+
+### OpenSSF is an influential advocate for efforts that are aligned with its mission
+- Support development and use of meaningful, actionable standards (e.g. SBOM formats, MFA?)
+- Catalyze improvements / action through targeted investment
+- ...
+
+> Approaches to achieve the above statement:
+> - Oversees time-bound projects to advocate for specific outcomes, e.g.
+>     - Great MFA distribution project
+>     - Sponsor of audits (via OSTIF & others) for critical projects
+> - TAC endorsement of specific standards-track efforts, to be incorporated across other OpenSSF foundation workstreams
+>     - Direct funding / staffing on tooling and adoption efforts (e.g. SPDX-Python)?
+>     - _question_: would it make sense to mandate use of the standard within foundation-hosted projects?
+> - (proposed) Engagement across platforms where developers already are (meetups, conferences, StackOverflow, etc)
+>     - _idea_: should OpenSSF hire dev-rel resources to staff this?
+
+### Regardless of (programming language, VCS, CI platform, etc), consumers of OSS can rely on clear & consistent trusted signals of:
+- Provenance of source code & artifacts
+- Security posture of projects and artifacts
+- Community health
+- Maintainer intent (e.g. project archived, not responsive to PRs, etc)
+- Consumer demand / criticality score(?)
+- ...
+
+> Approaches to achieve the above statement:
+> - OpenSSF hosts projects that produce these signals and/or make them trustworthy and actionable
+>     - OpenSSF funds the adoption of its projects (via SOS)
+> - OpenSSF hosts working groups that provide guidance on how to make use these signals
+> - Badging programs for projects
+> - End Users WG
+
+### Producers of OSS (at all skill levels; also explicitly are consumers of OSS through dependencies) have access to:
+- Best practices guides, education, etc
+- Extremely low-friction tooling to make security processes less onerous, more accurate, and trusted (burden of maintenance offloaded through opt-in automation)
+- Ability to start new projects from a more secure default position
+- Ensure sufficient staffing, auditing, pen testing, rigor for critical projects
+- ...
+
+> Approaches to achieve the above statement:
+> - OpenSSF hosts projects that produce tools that minimizes burden on project maintainers
+> - OpenSSF hosts working groups that publish & maintain recommendations on how to produce secure OSS, interface with consumers, etc


### PR DESCRIPTION
Per recent discussions at governing board and TAC meetings, the TAC is starting a process to update our technical vision to both:

- help provide greater external clarity on what the foundation wants to achieve in the next few years, and
- help align community & staff against an execution model that helps to deliver on the vision.

This PR aims to start the dialog with some thoughts I've written down based on several conversations over the few weeks; feedback and input from the community is extremely welcome.

Aside: since there can be confusion on the use of the words `{mission,vision,strategy}`, I've included the definitions used below:

- **Mission**: the purpose of the foundation / reason for existence 
    - _Note: the foundation's mission is set by the governing board, not the TAC_
- **Vision**: a description of the desired end state (2-5 years out) 
    - _Note: the TAC owns this deliverable per [foundation charter](https://charter.openssf.org)_
- **Strategy**: logic applied to reach vision

@joshbressers @lukehinds @dlorenc @inferno-chromium @AevaOnline @SecurityCRob FYI