### PR TITLE
Add projects table to README and clarify status of sigstore as an OpenSSF project

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,25 @@ The following Technical Initatives have been approved by the TAC:
 
 ### Projects
 
-| Name                       | Repository          | Notes                                                                                                 | Status     |
-| -------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------- | ---------- |
-| Sigstore                   | github.com/sigstore | [Meeting Notes](https://docs.google.com/document/d/1bsl-Y0KulSD7O_nTekad1sAKOVRb80wyGb-Q5x-zdg0/edit) | Incubating |
-| GNU Toolchain Improvements | Coming Soon         | ?                                                                                                     | Incubating |
-| Alpha Omega                | Coming Soon         | ?                                                                                                     | Incubating |
+| Name                       | Repository          | Notes                                                                                                 | Sponsoring Org | Status     |
+| ---------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------- |---------- |
+| Allstar                | https://github.com/ossf/allstar                  | [Meeting Notes](https://docs.google.com/document/d/1dB2U7_qZpNW96vtuoG7ShmgKXzIg6R5XT5Tc-0yz6kE/edit#heading=h.4k8ml0qkh7tl) | Best Practices WG               | TBD        |
+| Criticality Score      | https://github.com/ossf/criticality_score        | [Meeting Notes](https://docs.google.com/document/d/1MIXxadtWsaROpFcJnBtYnQPoyzTCIDhd0IGV8PIV0mQ/edit) | Securing Critical Projects WG   | TBD        |
+| Fuzz Introspector      | https://github.com/ossf/fuzz-introspector        | [Meeting Notes](https://docs.google.com/document/d/1DoB7zgtLsP-JGF77ASkHV7UMofTE2wseniexaa6Q4M8/edit#) | Security Tooling WG            | TBD        |
+| OSV Schema             | https://github.com/ossf/osv-schema               | [Meeting Notes](https://docs.google.com/document/d/1mZEi6EvbH2mvn-gHOUIaysAjHlwJXjJdJ7gMlelSkVU/edit#) | Vulnerability Disclosures WG   | TBD        |
+| Package Analysis       | https://github.com/ossf/package-analysis         | [Meeting Notes](https://docs.google.com/document/d/1MIXxadtWsaROpFcJnBtYnQPoyzTCIDhd0IGV8PIV0mQ/edit) | Securing Critical Projects WG   | TBD        |
+| Package Feeds          | https://github.com/ossf/package-feeds            | [Meeting Notes](https://docs.google.com/document/d/1MIXxadtWsaROpFcJnBtYnQPoyzTCIDhd0IGV8PIV0mQ/edit) | Securing Critical Projects WG   | TBD        |
+| Scorecard              | https://github.com/ossf/scorecard                | [Meeting Notes](https://docs.google.com/document/d/1dB2U7_qZpNW96vtuoG7ShmgKXzIg6R5XT5Tc-0yz6kE/edit#heading=h.4k8ml0qkh7tl) | Best Practices WG               | TBD        |
+| Security Insights Spec | https://github.com/ossf/security-insights-spec   | [Meeting Notes](https://docs.google.com/document/d/1AfI0S6VjBCO0ZkULCYZGHuzzW8TPqO3zYxRjzmKvUB4/edit?usp=sharing) | Identifying Security Threats WG | TBD        |
+| Security Metrics       | https://github.com/ossf/Project-Security-Metrics | [Meeting Notes](https://docs.google.com/document/d/1AfI0S6VjBCO0ZkULCYZGHuzzW8TPqO3zYxRjzmKvUB4/edit?usp=sharing) | Identifying Security Threats WG | TBD        |
+| Sigstore               | https://github.com/sigstore                      | [Meeting Notes](https://docs.google.com/document/d/1bsl-Y0KulSD7O_nTekad1sAKOVRb80wyGb-Q5x-zdg0/edit) | OpenSSF TAC    | TBD        |
+
+### OpenSSF affliated projects
+
+| Name                         | Repository                          | Notes | Status |
+| --------------------------   | ----------------------------------- | ----- | ------ |
+| GNU Toolchain Infrastructure | Coming Soon                         | TBD   | TBD    |
+| Alpha Omega                  | https://github.com/ossf/alpha-omega | TBD   | TBD    |
 
 Charters for these Technical Intiatives are located in the [Charters](charters)
 directory of this repository.

--- a/organizational-structure-overview.md
+++ b/organizational-structure-overview.md
@@ -36,7 +36,7 @@ The following table describes the main types of groups and their characteristics
 
 ### TODO
 
-* define and document the governance relationships for Alpha/Omega, GNU Toolchain Initiative, and SigStore (collectively, "SIFs")
+* define and document the governance relationships for affiliated projects: Alpha/Omega, GNU Toolchain Infrastructure 
 * define **Contributors** in a consistent way, so that electorate membership can be consistently, and ideally procedurally, determined
 * define criteria for approving or disapproving the Charters of TAC-subordinate bodies
 
@@ -50,7 +50,7 @@ Legend:
 
 ```mermaid
 flowchart TB
-    A([GoverningBoard])
+    A([Governing Board])
 
     subgraph subC[Committees]
         direction TB
@@ -72,10 +72,21 @@ flowchart TB
         ST[Security Tooling]
         VD[Vulnerability Disclosures]
 
-        ST ---> P2[Scorecards]
-        SCI ---> P3[SLSA]
+        BP ---> Allstar[Allstar]
+        BP ---> Scorecard[Scorecard]
+        IST ---> SecurityInsights[Security Insights]
+        IST ---> SecurityMetrics[Security Metrics]
+        SCI ---> SLSA[SLSA]
+        SCP ---> CriticalityScore[Criticality Score]
+        SCP ---> PackageAnalysis[Package Analysis]
+        SCP ---> PackageFeeds[Package Feeds]
+        ST ---> FuzzIntrospector[Fuzz Introspector]
+        VD ---> OSV[OSV Schema]
     end
     B ====> subWG
 
-    B ----> P1[Example Project]
+    subgraph projects[Projects]
+       SS[sigstore]
+    end
+    B ====> projects
 ```


### PR DESCRIPTION
The [README.md](https://github.com/ossf/tac/blob/main/README.md) at the root of this repo doesn't list out the projects that are part of the OpenSSF. This PR adds a table with information about those projects.

In addition, this PR removes ambiguity from how sigstore is described within the TAC repo, and represents an affirmation from the TAC that sigstore is officially and unequivocally an OpenSSF project that reports directly to the OpenSSF TAC. This affirmation is supported by the following facts: 

- sigstore joined the OpenSSF as a project reporting directly to the TAC upon a [unanimous vote at the November 16, 2021 meeting](https://github.com/ossf/tac/issues/64) 
-  sigstore community members have [regularly reported to the OpenSSF TAC](https://docs.google.com/document/d/18BJlokTeG5e5ARD1VFDl5bIP75OFPCtzf77lfadQ4f0/edit#) at the same depth and frequency as other working groups over the past several months
- In support of operating public good instances of the sigstore transparency log and certificate authority, sigstore fundraised bootstrap funding before joining the OpenSSF.
- Even while maintaining its own funds, sigstore is currently operating within the bounds of the [OpenSSF charter](https://charter.openssf.org/), which denotes in section 3.j.viii that the OpenSSF GB can "approve directed fundraising proposals for specific Working Groups or Projects that will raise and spend funds within the Working Group or Project". The recently approved project lifecycle process also explicitly acknowledges [that projects/working groups may raise funds in support of their work](https://github.com/ossf/tac/blob/79bb6546d504484818c8d9aabc5b02146b958c46/process/project-lifecycle.md?plain=1#L84)  
- sigstore is already being advertised as an OpenSSF project on official OpenSSF channels (including its [website](https://openssf.org/community/sigstore/) and Twitter [account](https://twitter.com/theopenssf/status/1585698716543029248?s=20&t=9WuPGnhuYMX2eO_Ad63ZgA)) 

The intent of this PR is that all OpenSSF community members and staff no longer refer to sigstore as a "SIF" and instead refer to it as an OpenSSF project reporting directly to the TAC.

@brianbehlendorf @dlorenc @AevaOnline @lukehinds @inferno-chromium @SecurityCRob @joshbressers

Signed-off-by: Bob Callaway <bcallaway@google.com>