### PR TITLE
Adding TAC and SCIR election process description and timeline

### DIFF
--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -11,6 +11,7 @@ The voter eligibility form asks you for an example of your contributions; this i
 If you have in any way been involved in or care about OpenSSF, but are in doubt as to whether your contribution “counts”, please fill it out anyways, and we will follow up.
 
 [Voter Eligibility Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSegUTOrxrGPVwDrPH9RARmYxX5YEkW3j67RU4uWABkKD5x8og/viewform)
+(Note: The form is only open during the nomination period)
 
  
 ## TAC Self-Nomination Process
@@ -19,6 +20,7 @@ The OpenSSF Technical Advisory Council (TAC) is composed of seven total individu
 Eligible community members, according to the same criteria defined above for voter eligibility, can self-nominate using the form below.
 
 [TAC Candidate Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSdxUbbfJGgjU_cZ_uGvUm-5ePoXu7q2pGiNyH2G8euwpn23Sw/viewform)
+(Note: The form is only open during the nomination period)
 
 
 ## SCIR Self-Nomination Information and Process
@@ -29,6 +31,7 @@ Familiarity with the different OpenSSF working groups and projects, and being ab
 It is also highly desired, but not required, that the SCIR be an eligible OpenSSF community member by the criteria defined above.
 
 [SCIR Candidate Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLScoabVVjW1kvTNcKXhTEdvxQd13Caql-I36MOixHVO1dLwIiQ/viewform)
+(Note: The form is only open during the nomination period)
 
 
 ## Election Process

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -16,7 +16,7 @@ If you have in any way been involved in or care about OpenSSF, but are in doubt 
 ## TAC Self-Nomination Process
 
 The OpenSSF Technical Advisory Council (TAC) is composed of seven total individuals, four of whom are elected annually.
-Eligable community members, according to the criteria defined above, can self-nominate using the form below.
+Eligible community members, according to the same criteria defined above for voter eligibility, can self-nominate using the form below.
 
 [TAC Candidate Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSdxUbbfJGgjU_cZ_uGvUm-5ePoXu7q2pGiNyH2G8euwpn23Sw/viewform)
 

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -55,9 +55,18 @@ The ballot will include the option to vote for both the TAC and SCIR.
 Questions related to the nomination and/or election process should be directed to [operations@openssf.org](mailto:operations@openssf.org).
 
 
-## 2023 Election Timeline
+## Standard Election Timeline
 
-The overall timeline for the 2023 election is as follows:
+The timeline in a standard election will follow the below format:
+
+10 months after the previous election, an election committee will be established by ...(a member of staff? a call for volunteers to $mailinglist?). The volunteers have two weeks to begin the election process.
+
+- Voter Ballot Request Period, and TAC and SCIR Self-Nomination Period - 2 weeks (concurrently)
+- Validation Period - 1 Week
+- Voting Period - 2 Weeks
+- Announcement of results - Day after the conclusion of the Voting Period
+
+For example, the overall timeline for the 2023 election is as follows:
 
 * Begin of overall election process: February 21
 * TAC Self-Nomination Period: February 21 - March 6 (2 weeks)

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -44,7 +44,7 @@ Candidates for each election will be reviewed by the Election Officials to ensur
 
 Similarly, the pool of eligible voters will be reviewed by Election Officials to ensure that all voters meet the eligibility criteria established above If a ballot requester is considered ineligible, an Election Official will follow up directly with the individual.
 
-If there are more nominees than positions for either the TAC or the SCIR, the election will be conducted using the electronic voting tool Opavote.
+If there are more nominees than positions for either the TAC or the SCIR, the election will be conducted using an electronic voting tool.
 The [Single Transferable Vote](https://en.wikipedia.org/wiki/Single_transferable_vote) method will be used to vote for TAC members as there are multiple candidates for multiple positions.
 Eligible voters will receive an invitation to access their ballot from Opavote.
 The ballot will include the option to vote for both the TAC and SCIR.

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -38,7 +38,7 @@ The Election Process will be monitored by Election Officials, who
 * approve the election timeline, and
 * review the ballot request form and validate voter eligibility.
 
-Election Officials are eligable community members who are not running for a TAC or SCIR position, but may cast a vote.
+Election Officials are eligible community members who have volunteered to oversee and help ensure the integrity of the election process. By volunteering in this role, they recuse themselves from running for a TAC or SCIR position but they still are allowed to vote in the election.
 
 During the validation period, the Election Officials will review the pool of eligible voters to confirm eligibility to participate in the election, per the guidelines defined above.
 At the conclusion of the validation period, Election Officials will publish the complete list of candidates.

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -7,7 +7,7 @@ This document outlines the election process for the OpenSSF Technical Advisory C
 
 Any contributor to OpenSSF working groups, SIGs, or projects is eligible to participate in the election.
 Valid contributions include: commits or submitted pull requests via Github; public edits or comments on Google docs or other work products associated with OpenSSF; posting messages to any mailing list or on Slack; and beyond that any other form of positive engagement with OpenSSF activities.
-The form asks you for an example of your contributions; this is merely to make it easier for the Election Officials and OpenSSF staff to validate eligability.
+The voter eligibility form asks you for an example of your contributions; this is merely to make it easier for the Election Officials and OpenSSF staff to validate eligibility.
 If you have in any way been involved in or care about OpenSSF, but are in doubt as to whether your contribution “counts”, please fill it out anyways, and we will follow up.
 
 [Voter Eligibility Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSegUTOrxrGPVwDrPH9RARmYxX5YEkW3j67RU4uWABkKD5x8og/viewform)

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -42,7 +42,7 @@ Election Officials are eligible community members who have volunteered to overse
 
 Candidates for each election will be reviewed by the Election Officials to ensure their eligibility per the guidelines above. At the end of the validation period, the complete list of candidates will be published in this repo.
 
-Similarly, the pool of eligible voters will be reviewed by Election Officials to ensure that all voters meet the eligibility criteria established above If a ballot requester is considered ineligible, an Election Official will follow up directly with the individual.
+Similarly, the pool of eligible voters will be reviewed by Election Officials to ensure that all voters meet the eligibility criteria established above. If a ballot requester is considered ineligible, the requester will be notified directly by one of the Election Officials.
 
 If there are more nominees than positions for either the TAC or the SCIR, the election will be conducted using an electronic voting tool.
 The [Single Transferable Vote](https://en.wikipedia.org/wiki/Single_transferable_vote) method will be used to vote for TAC members as there are multiple candidates for multiple positions.

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -40,8 +40,9 @@ The Election Process will be monitored by Election Officials, who
 
 Election Officials are eligible community members who have volunteered to oversee and help ensure the integrity of the election process. By volunteering in this role, they recuse themselves from running for a TAC or SCIR position but they still are allowed to vote in the election.
 
-During the validation period, the Election Officials will review the pool of eligible voters to confirm eligibility to participate in the election, per the guidelines defined above.
-At the conclusion of the validation period, Election Officials will publish the complete list of candidates.
+Candidates for each election will be reviewed by the Election Officials to ensure their eligibility per the guidelines above. At the end of the validation period, the complete list of candidates will be published in this repo.
+
+Similarly, the pool of eligible voters will be reviewed by Election Officials to ensure that all voters meet the eligibility criteria established above If a ballot requester is considered ineligible, an Election Official will follow up directly with the individual.
 
 If there are more nominees than positions for either the TAC or the SCIR, the election will be conducted using the electronic voting tool Opavote.
 The [Single Transferable Vote](https://en.wikipedia.org/wiki/Single_transferable_vote) method will be used to vote for TAC members as there are multiple candidates for multiple positions.

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -44,7 +44,7 @@ During the validation period, the Election Officials will review the pool of eli
 At the conclusion of the validation period, Election Officials will publish the complete list of candidates.
 
 If there are more nominees than positions for either the TAC or the SCIR, the election will be conducted using the electronic voting tool Opavote.
-A Single Transferable Voting method will be used for the TAC as there are multiple candidates. 
+The [Single Transferable Vote](https://en.wikipedia.org/wiki/Single_transferable_vote) method will be used to vote for TAC members as there are multiple candidates for multiple positions.
 Eligible voters will receive an invitation to access their ballot from Opavote.
 The ballot will include the option to vote for both the TAC and SCIR.
 

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -6,7 +6,7 @@ This document outlines the election process for the OpenSSF Technical Advisory C
 ## Voter Eligibility (Electorate) Self-Nomination Process
 
 Any contributor to OpenSSF working groups, SIGs, or projects is eligible to participate in the election.
-Valid contributions include: commits or submitted pull requests via Github; public edits or comments on Google docs or other work products associated with OpenSSF; posting messages to any mailing list or on Slack; and beyond that any other form of positive engagement with OpenSSF activities.
+Valid contributions include: commits or submitted pull requests via Github; public edits or comments on Google docs or other work products associated with OpenSSF; consistent participation in working groups; posting messages to any mailing list or on Slack; and beyond that any other form of positive engagement with OpenSSF activities.
 The voter eligibility form asks you for an example of your contributions; this is merely to make it easier for the Election Officials and OpenSSF staff to validate eligibility.
 If you have in any way been involved in or care about OpenSSF, but are in doubt as to whether your contribution “counts”, please fill it out anyways, and we will follow up.
 

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -26,7 +26,7 @@ Eligible community members, according to the same criteria defined above for vot
 Since early in its existence, the OpenSSF Governing Board has sought to ensure it gets adequate input from voices in the software security community who would otherwise not be at the table.
 We seek candidates for the Security Community Individual Representative (SCIR) who can represent those voices, while also being a subject matter expert in the field with their own set of perspectives.
 Familiarity with the different OpenSSF working groups and projects, and being able to dedicate the time to be sufficiently informed on the issues that arise in our monthly calls and ongoing discussions, is highly desired.
-It is also highly desired, but not required, that the SCIR be a contributor and thus eligible to vote in the election.
+It is also highly desired, but not required, that the SCIR be an eligible OpenSSF community member by the criteria defined above.
 
 [SCIR Candidate Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLScoabVVjW1kvTNcKXhTEdvxQd13Caql-I36MOixHVO1dLwIiQ/viewform)
 

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -1,0 +1,65 @@
+# TAC and SCIR Election Procedures
+
+This document outlines the election process for the OpenSSF Technical Advisory Council (TAC) and Security Community Individual Representative (SCIR).
+
+
+## Voter Eligibility (Electorate) Self-Nomination Process
+
+Any contributor to OpenSSF working groups, SIGs or projects is eligible to participate in the election.
+Valid contributions include: commits or submitted pull requests via Github; public edits or comments on Google docs or other work products associated with OpenSSF; posting messages to any mailing list or on Slack; and beyond that any other form of positive engagement with OpenSSF activities.
+The form asks you for an example of your contributions; this is merely to make it easier for the Election Officials and OpenSSF staff to validate eligability.
+If you have in any way been involved in or care about OpenSSF, but are in doubt as to whether your contribution “counts”, please fill it out anyways, and we will follow up.
+
+[Voter Eligibility Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSegUTOrxrGPVwDrPH9RARmYxX5YEkW3j67RU4uWABkKD5x8og/viewform)
+
+ 
+## TAC Self-Nomination Process
+
+The OpenSSF Technical Advisory Council (TAC) is composed of seven total individuals, four of whom are elected annually.
+Eligable community members, according to the criteria defined above, can self-nominate using the form below.
+
+[TAC Candidate Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSdxUbbfJGgjU_cZ_uGvUm-5ePoXu7q2pGiNyH2G8euwpn23Sw/viewform)
+
+
+## SCIR Self-Nomination Information and Process
+
+Since early in its existence, the OpenSSF Governing Board has sought to ensure it gets adequate input from voices in the software security community who would otherwise not be at the table.
+We seek candidates for the Security Community Individual Representative (SCIR) who can represent those voices, while also being a subject matter expert in the field with their own set of perspectives.
+Familiarity with the different OpenSSF working groups and projects, and being able to dedicate the time to be sufficiently informed on the issues that arise in our monthly calls and ongoing discussions, is highly desired.
+It is also highly desired, but not required, that the SCIR be a contributor and thus eligible to vote in the election.
+
+[SCIR Candidate Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLScoabVVjW1kvTNcKXhTEdvxQd13Caql-I36MOixHVO1dLwIiQ/viewform)
+
+
+## Election Process
+
+The Election Process will be monitored by Election Officials, who
+* review nominees and confirm their eligibility,
+* approve the election timeline, and
+* review the ballot request form and validate voter eligibility.
+
+Election Officials are eligable community members who are not running for a TAC or SCIR position, but may cast a vote.
+
+During the validation period, the Election Officials will review the pool of eligible voters to confirm eligibility to participate in the election, per the guidelines defined above.
+At the conclusion of the validation period, Election Officials will publish the complete list of candidates.
+
+If there are more nominees than positions for either the TAC or the SCIR, the election will be conducted using the electronic voting tool Opavote.
+A Single Transferable Voting method will be used for the TAC as there are multiple candidates. 
+Eligible voters will receive an invitation to access their ballot from Opavote.
+The ballot will include the option to vote for both the TAC and SCIR.
+
+Questions related to the nomination and/or election process should be directed to [operations@openssf.org](mailto:operations@openssf.org).
+
+
+## 2023 Election Timeline
+
+The overall timeline for the 2023 election is as follows:
+
+* Begin of overall election process: February 21
+* TAC Self-Nomination Period: February 21 - March 6 (2 weeks)
+* SCIR Self-Nomination Period: February 21 - March 6 (2 weeks)
+* Voter Ballot Request Period: February 21 - March 6 (2 weeks)
+* Validation Period: March 7 - March 13 (1 week)
+* Nominees Announced: March 14
+* Voting Period: March 14 - March 27 (2 weeks)
+* Announcement of election results: March 28 

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -5,7 +5,7 @@ This document outlines the election process for the OpenSSF Technical Advisory C
 
 ## Voter Eligibility (Electorate) Self-Nomination Process
 
-Any contributor to OpenSSF working groups, SIGs or projects is eligible to participate in the election.
+Any contributor to OpenSSF working groups, SIGs, or projects is eligible to participate in the election.
 Valid contributions include: commits or submitted pull requests via Github; public edits or comments on Google docs or other work products associated with OpenSSF; posting messages to any mailing list or on Slack; and beyond that any other form of positive engagement with OpenSSF activities.
 The form asks you for an example of your contributions; this is merely to make it easier for the Election Officials and OpenSSF staff to validate eligability.
 If you have in any way been involved in or care about OpenSSF, but are in doubt as to whether your contribution “counts”, please fill it out anyways, and we will follow up.

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -52,6 +52,9 @@ The [Single Transferable Vote](https://en.wikipedia.org/wiki/Single_transferable
 Eligible voters will receive an invitation to access their ballot from Opavote.
 The ballot will include the option to vote for both the TAC and SCIR.
 
+If the number of eligible nominees is less then the number of open positions, then all eligigle nominees will be appointed and a second nomination phase for filling the remaining positions will be opened.
+If the number of eligible nominees equals the number of open positions, then those nominees will be elected unopposed.
+
 Questions related to the nomination and/or election process should be directed to [operations@openssf.org](mailto:operations@openssf.org).
 
 


### PR DESCRIPTION
The procedure for the TAC and SCIR elections has not yet been officially documented. In preparation for the 2023 elections of the TAC and SCIR members, the Election Officials would like to document the entire election process, including the specific timeline for the 2023 elections.

This document is based on the procedure used during the 2022 elections [1], based on discussions in the TAC in preparation for the 2022 election [2].

[1] https://lists.openssf.org/g/openssf-tac/message/406
[2] https://lists.openssf.org/g/openssf-tac/message/364