### PR TITLE
update TAC member list for the year

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Meetings are also recorded and posted to the [OpenSSF YouTube channel](https://w
 
 ## Members
 
-| Name          | Email                          | Organization | Term                     |
-| ------------- | ------------------------------ | ------------ | -------------------------|
-| Abhishek Arya | aarya@google.com               | Google       | April 2022 - March 2023  |
-| Aeva Black    | aeva.black@microsoft.com       | Microsoft    | April 2022 - March 2023\* |
-| Bob Callaway  | bcallaway@google.com           | Google       | April 2022 - March 2023  |
-| CRob Robinson | christopher.robinson@intel.com | Intel        | April 2022 - March 2023\* |
-| Dan Lorenc    | dlorenc@chainguard.dev         | Chainguard   | April 2022 - March 2023  |
-| Josh Bressers | josh.bressers@anchore.com      | Anchore      | April 2022 - March 2023\* |
-| Luke Hinds    | lhinds@redhat.com              | Red Hat      | April 2022 - March 2023  |
+| Name             | Email                          | Organization | Term                      |
+| ---------------- | ------------------------------ | ------------ | --------------------------|
+| Aeva Black       | aeva.black@microsoft.com       | Microsoft    | April 2023 - March 2024   |
+| Arnaud J Le Hors | lehors@us.ibm.com              | IBM          | April 2023 - March 2024\* |
+| Bob Callaway     | bcallaway@google.com           | Google       | April 2023 - March 2024   |
+| CRob Robinson    | christopher.robinson@intel.com | Intel        | April 2023 - March 2024\* |
+| Dan Lorenc       | dlorenc@chainguard.dev         | Chainguard   | April 2023 - March 2024   |
+| Dustin Ingram    | dii@google.com                 | Google       | April 2023 - March 2024   |
+| Zach Steindler   | steiza@github.com              | GitHub       | April 2023 - March 2024\* |
 
 NOTE: \* marked entries denote OpenSSF Governing Board appointed members, others are community elected.
 


### PR DESCRIPTION
Election and appointments results have been announced to the TAC mailing list.  The readme is due an update.