### PR TITLE
Charter references different link

### DIFF
--- a/organizational-structure-overview.md
+++ b/organizational-structure-overview.md
@@ -2,7 +2,7 @@
 
 ## OpenSSF Charter
 
-The overall governance of the OpenSSF is defined in [the Foundation Charter](https://cdn.platform.linuxfoundation.org/agreements/openssf.pdf) (PDF file). 
+The overall governance of the OpenSSF is defined in [the OpenSSF Charter](https://openssf.org/about/charter/). 
 
 
 ## Definitions


### PR DESCRIPTION
The original link for the "Foundation Charter" was for the [participation agreement](https://cdn.platform.linuxfoundation.org/agreements/openssf.pdf). I changed this to the actual OpenSSF Charter