### PR TITLE
policy: add github org membership section

### DIFF
--- a/policies/access.md
+++ b/policies/access.md
@@ -27,6 +27,12 @@ Note: this list is intentionally not exhaustive.
     This is the parent team for projects. Every project (e.g. scorecard, AO) should have a subteam contained within this one.
     Teams for individual repositories go under here, which start with `repo-`, but team names may otherwise be unconstrained.
 
+## GitHub Org Membership
+
+ Membership in the GitHub org should be freely given - it inherently confers no permissions or privileges, only a badge on the user's profile if they enable it - and it _does_ allow for easier team management. Someone should only be removed from the org in extreme circumstances where their association with OpenSSF would be problematic, and people should be encouraged to remain in the org in perpetuity.
+
+ Individuals are free to choose to be a member of the org or not, but membership is required to be on GitHub teams, which grants privileged access to repositories.
+
 ## Principle of Least Privilege
 
  Permission levels should be as high as they need to be, and no higher.


### PR DESCRIPTION
Followup from #155 and https://github.com/ossf/tac/pull/155#discussion_r1202754183

There are currently no dangerous permissions inherently granted by being a member of the github org, and I don't foresee anyone changing that (at all, let alone without broad discussion and TAC approval).

Note: the wording here is "should", intentionally - this paragraph in no way obligates OpenSSF to add anyone to the github org. However, once someone is _in_ the org, they can be freely added to and removed from teams - prior to being in the org, they have to accept an invitation that expires in 7 days, so it's harder to use teams as a self-documenting structure when you have to wait on invitation acceptance.