### PR TITLE
Include SBOMit application words to wordlist

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -18,6 +18,7 @@ Benzies
 blogging
 Brasseur
 Bressers
+Cappos
 CEOs
 chainguard
 Channable
@@ -29,6 +30,7 @@ Civs
 CLA
 CNCF
 Coinbase
+colek
 Corail
 CPython
 crob
@@ -38,6 +40,7 @@ CVD
 CVEs
 CVRF
 Cybeats
+Datadog
 Dcmiddle
 dco
 Debian
@@ -52,6 +55,7 @@ Fernick
 Ferraioli
 Foxboron
 frenemy
+FRSCA
 fyi
 Gendreau
 Gesmer
@@ -63,6 +67,7 @@ headcount
 HUAWEI
 Hyperledger
 hyperlinks
+idunbarh
 impactfully
 jburson
 JFrog
@@ -70,6 +75,7 @@ jorydotcom
 joshbressers
 JPM
 JPMC
+justincappos
 Kaczorowski
 Kairo
 kairoaraujo
@@ -80,6 +86,7 @@ Kimmich
 Knative
 Konstantinos
 Kratzer
+Kuppusamy
 kusari
 Lakkakula
 lehors
@@ -96,6 +103,7 @@ lumjjb
 maintainership
 malware
 mds
+mnm
 Montazery
 Mozilla
 mvrachev
@@ -142,6 +150,7 @@ RPi
 Rubygems
 Rutkowski
 Sandecki
+SBO
 SBOMs
 Schaik
 scim
@@ -171,6 +180,8 @@ tac
 TCs
 timeframes
 timezones
+Trishank
+trishankatdatadog
 TSC
 tuf
 typosquatting


### PR DESCRIPTION
This ensures the "check spelling bot" will pass the application document.