### PR TITLE
Tune check-spelling

### DIFF
--- a/.github/actions/spelling/advice.md
+++ b/.github/actions/spelling/advice.md
@@ -1,31 +1,4 @@
 <!-- See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples%3A-advice --> <!-- markdownlint-disable MD033 MD041 -->
-<details><summary>If the flagged items are :exploding_head: false positives</summary>
+If items reported here are typos that you've added, please fix them.
 
-If items relate to a ...
-* binary file (or some other file you wouldn't want to check at all).
-
-  Please add a file path to the `excludes.txt` file matching the containing file.
-
-  File paths are Perl 5 Regular Expressions - you can [test](
-https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your files.
-
-  `^` refers to the file's path from the root of the repository, so `^README\.md$` would exclude [README.md](
-../tree/HEAD/README.md) (on whichever branch you're using).
-
-* well-formed pattern.
-
-  If you can write a [pattern](
-https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns
-) that would match it,
-  try adding it to the `patterns.txt` file.
-
-  Patterns are Perl 5 Regular Expressions - you can [test](
-https://www.regexplanet.com/advanced/perl/) yours before committing to verify it will match your lines.
-
-  Note that patterns can't match multiline strings.
-
-</details>
-
-<!-- adoption information-->
-:steam_locomotive: If you're seeing this message and your PR is from a branch that doesn't have check-spelling,
-please merge to your PR's base branch to get the version configured for your repository.
+You can ignore anything that you haven't added.

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -80,7 +80,6 @@ jobs:
       contents: read
       pull-requests: read
       actions: read
-      security-events: write
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
@@ -100,8 +99,8 @@ jobs:
         spell_check_this: ossf/tac@main
         post_comment: 0
         use_magic_file: 1
-        experimental_apply_changes_via_bot: ${{ github.repository_owner != 'ossf' && 1 }}
-        use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
+        quit_without_error: 1
+        only_check_changed_files: 1
         extra_dictionary_limit: 10
         dictionary_source_prefixes: |
           {"cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20220816/dictionaries/", "cspell1": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20230509/dictionaries/"}
@@ -110,27 +109,44 @@ jobs:
           cspell1:aws/aws.txt
           cspell1:k8s/dict/k8s.txt
           cspell1:filetypes/filetypes.txt
+        check_extra_dictionaries: ''
 
-  update:
-    name: Update PR
+  comment-push:
+    name: Report (Push)
+    # If your workflow isn't running on push, you can remove this job
+    runs-on: ubuntu-latest
+    needs: spelling
     permissions:
       contents: write
-      pull-requests: write
-      actions: read
-    runs-on: ubuntu-latest
     if: ${{
+        (success() || failure()) &&
         github.repository_owner != 'ossf' &&
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@check-spelling-bot apply')
+        needs.spelling.outputs.followup &&
+        github.event_name == 'push'
       }}
-    concurrency:
-      group: spelling-update-${{ github.event.issue.number }}
-      cancel-in-progress: false
+
     steps:
-    - name: apply spelling updates
-      uses: check-spelling/check-spelling@v0.0.21
+    - name: comment
+      uses: check-spelling/check-spelling@main
       with:
-        experimental_apply_changes_via_bot: 1
         checkout: true
-        ssh_key: "${{ secrets.CHECK_SPELLING }}"
+        spell_check_this: check-spelling/spell-check-this@prerelease
+        only_check_changed_files: 1
+        task: ${{ needs.spelling.outputs.followup }}
+
+  comment-pr:
+    name: Report (PR)
+    # If you workflow isn't running on pull_request*, you can remove this job
+    runs-on: ubuntu-latest
+    needs: spelling
+    permissions:
+      pull-requests: write
+    if: (success() || failure()) && needs.spelling.outputs.followup && contains(github.event_name, 'pull_request')
+    steps:
+    - name: comment
+      uses: check-spelling/check-spelling@main
+      with:
+        checkout: true
+        spell_check_this: check-spelling/spell-check-this@prerelease
+        only_check_changed_files: 1
+        task: ${{ needs.spelling.outputs.followup }}


### PR DESCRIPTION
This is an alternative to #201 as proposed in https://github.com/ossf/tac/pull/201#issuecomment-1727940640

* Add commenting on PRs
* Add commenting on push for repositories not in ossf
* Disable failure status reporting
* Only check changed files
  * Disable sarif reporting
  * Remove update job
* Adjust advice

With these changes, you'll get a comment like this: https://github.com/check-spelling-sandbox/tac/pull/3#issuecomment-1728284295 and no ❌.