### PR TITLE
Add instructions and templates for creating or advancing a WG

### DIFF
--- a/process/templates/PROJECT_NAME_archived_stage.md
+++ b/process/templates/PROJECT_NAME_archived_stage.md
@@ -1,5 +1,5 @@
 ## Application for archiving of a project
 
 ### Reasons for archiving
-Projects may become inactive over time or do not want to be supported by OpenSSF any longer.
+Projects may become inactive over time or not want to be supported by OpenSSF any longer.
   * "description of why this project should be archived"

--- a/process/templates/WG_NAME_archived_stage.md
+++ b/process/templates/WG_NAME_archived_stage.md
@@ -1,0 +1,7 @@
+## Application for archiving of a Working Group
+
+### Reasons for archiving
+
+The work has stopped because it has completed its chartered deliverables or is no longer progressing on its deliverables as determined by the TAC.
+
+* "description of why this WG should be archived"

--- a/process/templates/WG_NAME_graduation_stage.md
+++ b/process/templates/WG_NAME_graduation_stage.md
@@ -1,7 +1,7 @@
 ## Working Group graduation application
 
-### List of regular members
-The WG must have at least 5 members from at least 3 different organizations attending regularly as recorded in meeting minutes.
+### List of regular contributors
+The WG must have at least 5 contributors from at least 3 different organizations attending regularly as recorded in meeting minutes.
 
   * "name, affiliation, GitHub ID"
 

--- a/process/templates/WG_NAME_graduation_stage.md
+++ b/process/templates/WG_NAME_graduation_stage.md
@@ -1,0 +1,11 @@
+## Working Group graduation application
+
+### List of regular members
+The WG must have at least 5 members from at least 3 different organizations attending regularly as recorded in meeting minutes.
+
+  * "name, affiliation, GitHub ID"
+
+### Working Group activity
+The WG must have met at least 4 times over a period of at least 2 months since becoming `Incubating`
+
+  * Link to public meeting notes (or ideally recordings)

--- a/process/templates/WG_NAME_incubating_stage.md
+++ b/process/templates/WG_NAME_incubating_stage.md
@@ -1,7 +1,7 @@
 ## Working Group incubation application
 
-### List of regular members
-The WG must have a minimum of 5 members from at least 3 different organizations attending regulary.
+### List of regular contributors
+The WG must have a minimum of 5 contributors from at least 3 different organizations attending regulary.
 
   * "name, affiliation, GitHub ID"
 

--- a/process/templates/WG_NAME_incubating_stage.md
+++ b/process/templates/WG_NAME_incubating_stage.md
@@ -1,0 +1,21 @@
+## Working Group incubation application
+
+### List of regular members
+The WG must have a minimum of 5 members from at least 3 different organizations attending regulary.
+
+  * "name, affiliation, GitHub ID"
+
+### TAC sponsor
+The WG must have a TAC sponsor:
+
+  * "name, affiliation, GitHub ID"
+
+### Mission of the Working Group
+The WG must have a charter or mission statement for review by TAC
+
+  * Link to the WG charter or mission statement defining its goals.
+
+### Working Group activity
+The WG must have met at least 5 times
+
+   * Link to public meeting notes (or ideally recordings)

--- a/process/templates/WG_NAME_sandbox_stage.md
+++ b/process/templates/WG_NAME_sandbox_stage.md
@@ -1,0 +1,22 @@
+## Application for creating a new Working Group at Sandbox stage
+
+### List of interested individuals
+The WG must have a minimum of 3 interested individual from different organizations.
+  * "name, affiliation, GitHub ID"
+
+### Mission of the Working Group
+The WG must be aligned with the OpenSSF mission and address an unfulfilled need. It is preferred that topics falling with the scope of existing OpenSSF WGs are addressed within the existing wG rather than seek a new WG.
+  * "description of the WG mission"
+
+### IP policy and licensing due diligence
+When contributing to OpenSSF any existing material for the new WG to work on, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
+  * "yes / no / not applicable. If yes, provide a link to the corresponding GitHub issue."
+  
+### Working Group References
+The WG should provide a list of existing resources with links to the repository, and if available, website and any other material to showcase the existing breadth, maturity, and direction of the WG.
+
+| Reference          | URL |
+|--------------------|-----|
+| Repo               |     |
+| Website            |     |
+| Other              |     |

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -31,7 +31,7 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Have a charter or mission statement for review by TAC
 * Have met at least 5 times
     * For these, meeting notes (or ideally recordings) must be public
-* Have at least 5 interested individuals from at least 3 different organizations attending regularly
+* Have at least 5 members from at least 3 different organizations attending regularly
 * 1 TAC sponsor
     * TAC sponsor agrees to attend WG meetings regularly
     * TAC sponsor does not need to have a formal role in WG, e.g., chair
@@ -46,13 +46,13 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Meet on a regular cadence. Meetings are public, recorded, and on the calendar
 * Have access to community resources (Zooms, YouTube channels, GitHub, Slack channels, etc.)
 * Can request funding/other resources (subject to TAC/GB approval)
-    * NOTE: _At the time of this draft, funding and resources beyond collaboration tools have not been established in the OpenSSF. WGs should expect that their main resource is the community contributions they are able to recruit._
+    * NOTE: _At the time, funding and resources beyond collaboration tools have not been established in the OpenSSF. WGs should expect that their main resource is the community contributions they are able to recruit._
 
 ## To become `Graduated`:
 
 * Have received TAC approval of the README.md per `Incubating` requirements above
 * Have met at least 4 times over a period of at least 2 months since becoming `Incubating`
-* Have at least 5 regular members from at least 3 different organizations attending regularly as recorded in meeting minutes.
+* Have at least 5 members from at least 3 different organizations attending regularly as recorded in meeting minutes.
 * Request TAC approval. TAC will vote to approve or provide constructive guidance
 
 ## To remain `Graduated`:
@@ -77,3 +77,15 @@ A WG is expected to continue operating per the above guidelines, and to provide 
 * All significant artifacts should be archived as appropriate
 * Meeting series removed from calendar, mail list closed, and any other administrative items
   similarly put to closure as needed
+
+## Submission Process
+
+### Working Group creation or change of lifecycle stage
+
+For initiating the creation of a new WG or for requesting a change of a WG lifecycle stage, an application must be submitted to the TAC. To this end, a lead of the WG (or anyone in the case of an Archived WG) creates a PR in this repository with the following changes:
+
+* A new file in the `wg-lifecycle-documents` directory containing all information requested for a WG creation or a lifecycle change review. This file must be based on the template for the respective lifecycle stage in the `templates` directory. The `WG_NAME_` prefix of the template must be replaced by the WG name.
+
+* Modification of the table listing all projects in the [README](../README.md) of this repository by either updating the status field of the WG in the table to the intended new lifecycle stage or by adding the WG to the table in case of a WG creation request.
+
+The TAC members review the PR and upon approval according to voting criteria defined in the [OpenSSF charter](https://cdn.platform.linuxfoundation.org/agreements/openssf.pdf), the PR can be merged. The new WG has been created and the new lifecycle stage is in effect after the PR is merged.

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -31,7 +31,7 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Have a charter or mission statement for review by TAC
 * Have met at least 5 times
     * For these, meeting notes (or ideally recordings) must be public
-* Have at least 5 members from at least 3 different organizations attending regularly
+* Have at least 5 contributors from at least 3 different organizations attending regularly
 * 1 TAC sponsor
     * TAC sponsor agrees to attend WG meetings regularly
     * TAC sponsor does not need to have a formal role in WG, e.g., chair
@@ -52,7 +52,7 @@ Once the WG has further defined its goals and garnered enough support it can app
 
 * Have received TAC approval of the README.md per `Incubating` requirements above
 * Have met at least 4 times over a period of at least 2 months since becoming `Incubating`
-* Have at least 5 members from at least 3 different organizations attending regularly as recorded in meeting minutes.
+* Have at least 5 contributors from at least 3 different organizations attending regularly as recorded in meeting minutes.
 * Request TAC approval. TAC will vote to approve or provide constructive guidance
 
 ## To remain `Graduated`:

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -46,7 +46,7 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Meet on a regular cadence. Meetings are public, recorded, and on the calendar
 * Have access to community resources (Zooms, YouTube channels, GitHub, Slack channels, etc.)
 * Can request funding/other resources (subject to TAC/GB approval)
-    * NOTE: _At the time, funding and resources beyond collaboration tools have not been established in the OpenSSF. WGs should expect that their main resource is the community contributions they are able to recruit._
+    * NOTE: _At this time, funding and resources beyond collaboration tools have not been established in the OpenSSF. WGs should expect that their main resource is the community contributions they are able to recruit._
 
 ## To become `Graduated`:
 


### PR DESCRIPTION
The Project lifecycle documentation provides detailed instructions on how to go at proposing a new project and advancing a project from one stage to another. This PR adds similar instructions for Working Groups.
This also includes fixing a few typos.