### PR TITLE
TAC sponsor should be sandbox stage requirement for WGs

### DIFF
--- a/process/TI-Gives+Gets.md
+++ b/process/TI-Gives+Gets.md
@@ -14,17 +14,18 @@ Also note that benefits may actually vary based on resources and funds availabil
 
  * TI must be aligned with the OpenSSF mission and either be a novel approach for existing areas or address an unfulfilled need. It is expected that the initial code needed for an OpenSSF WG to work be kept within their repository and will not function as a project in its own right. Should initial WG code grow and mature that it warrants its own Project status, then it is subject to Sandbox entry requirements. It is preferred that extensions of existing OpenSSF projects collaborate with the existing project rather than seek a new project.
  * TI must maintain a diversified contributor base (i.e. not a single-vendor project).  TI must have a minimum of two maintainers with different organization affiliations.
- * TI must find an aligned WG to host the TI and must have a TAC sponsor that can help guide the TI through processes.
+ * WG must find a TAC sponsor that can help guide the WG through its sandbox stage.
+ * Project and or SIG must find an aligned WG to host the TI or must have a TAC sponsor that can help guide the TI through the sandbox stage.
  * TI agrees to follow the [Secure Software Development Guiding Principles](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/SecureSoftwareGuidingPrinciples.md) and the [Open Source Consumption Manifesto](https://github.com/ossf/wg-endusers/tree/main/MANIFESTO).
  * If contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
  * Provides quarterly updates to the TAC on technical vision and progress on vision.
- * TI will have a [SECURITY.md](https://github.com/ossf/project-template/blob/main/SECURITY.md) that describes how the Project manages vulnerabilities, or more broadly how the OSSF handles vulnerability reports
+ * TI will have a [SECURITY.md](https://github.com/ossf/project-template/blob/main/SECURITY.md) that describes how the Project manages vulnerabilities, or more broadly how the OSSF handles vulnerability reports.
 
 ### Gets/Benefits
 
- * TI can get assistance with Architecture & Roadmap Alignment
+ * TI can get assistance with Architecture & Roadmap Alignment.
  * Receives consideration as in-scope for any submission to an OpenSSF-managed conference or event.
- * TI receives guidance on technical direction from TAC sponsor
+ * TI receives guidance on technical direction from its TAC sponsor or hosting WG.
  * Reserved space for project updates in OpenSSF newsletters.
  * May request basic infrastructure support from the OpenSSF (e.g., mailing list and github repo).
  * Projects may say they are, "A sandbox project in the OpenSSF" or "An experimental project in the OpenSSF."  Gets a "sandbox" logo that is shared amongst all OpenSSF sandbox TIs.

--- a/process/project-lifecycle.md
+++ b/process/project-lifecycle.md
@@ -44,7 +44,7 @@ The OpenSSF Sandbox is the entry point for early stage Projects and has four goa
 * Provides project updates to OpenSSF Marketing Committee as requested.
 
 #### Project Support
-* Receives guidance on technical direction from TAC.
+* Receives a TAC and WG sponsor for guidance on technical direction.
 * Receives consideration as in-scope for any submission to an OpenSSF-managed conference or event.
 * Receives OpenSSF Code of Conduct Committee support.
 * Reserved space for project updates in OpenSSF newsletters.
@@ -55,6 +55,10 @@ The OpenSSF Sandbox is the entry point for early stage Projects and has four goa
 
 * Projects must have a minimum of two maintainers with different organization affiliations.
 * Projects must be aligned with the OpenSSF mission _and_ either be a novel approach for existing areas or address an unfulfilled need. It is expected that the initial code or specification developed by an OpenSSF WG be kept within their repository and will not function as a Project in its own right. Should the initial WG code or specification grow and mature that it warrants its own Project status, then it is subject to Sandbox entry requirements. It is preferred that extensions of an existing OpenSSF project collaborate with the existing project rather than seek a new project.
+* Projects must seek one TAC sponsor and one WG sponsor (if reporting to a WG)
+    * TAC or WG sponsor agrees to attend Project meetings regularly
+    * TAC or WG sponsor does not need to have a formal role in Project, e.g., maintainer
+    * TAC or WG sponsor requests TAC approval
 * If contributing an existing project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
 
 See [Submission Process](#submission-process) below and [Sandbox application](templates/PROJECT_NAME_sandbox_stage.md).
@@ -74,7 +78,6 @@ Incubating projects represent maturing but not fully realized projects. Incubati
 
 #### Project Support
 * Receives guidance on technical direction from TAC.
-* Receives a TAC or WG sponsor for guidance as an Incubation project.
 * Receives consideration as in-scope for any submission to an OpenSSF-managed conference or event.
 * Receives OpenSSF Code of Conduct Committee support.
 * Receives infrastructure support (details determined by project leads and OpenSSF Budget Committee).

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -16,6 +16,10 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Proposal of scope for review by TAC
     * This is to help ensure limited overlap with existing WGs
 * Have at least 3 interested individuals from different organizations supporting the proposal
+* 1 TAC sponsor
+    * TAC sponsor agrees to attend WG meetings regularly
+    * TAC sponsor does not need to have a formal role in WG, e.g., chair
+    * TAC sponsor requests TAC approval
 * TAC will vote to approve or provide constructive guidance
 
 ## Once `Sandbox`:
@@ -24,7 +28,7 @@ Once the WG has further defined its goals and garnered enough support it can app
 * If the WG has meetings at this stage:
   * They should appear on the OpenSSF calendar
   * The WG should have a document with upcoming agendas and notes from past meetings
-* The WG should develop a charter or mission statement defining its goals and seek a TAC sponsor.
+* The WG should develop a charter or mission statement defining its goals.
  
 ## To become `Incubating`:
 
@@ -32,10 +36,6 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Have met at least 5 times
     * For these, meeting notes (or ideally recordings) must be public
 * Have at least 5 contributors from at least 3 different organizations attending regularly
-* 1 TAC sponsor
-    * TAC sponsor agrees to attend WG meetings regularly
-    * TAC sponsor does not need to have a formal role in WG, e.g., chair
-    * TAC sponsor requests TAC approval
 * TAC will vote to approve or provide constructive guidance
 
 ## Once `Incubating`:


### PR DESCRIPTION
The current WG lifecycle process docs don't currently require a TAC sponsor until _after_ the sandbox stage has been reached, even though the intent is for WGs the have TAC sponsor _before_ applying for sandbox status. This PR adjusts the WG lifecycle process to reflect that having a TAC sponsor should be a requirement for WGs when applying for the sandbox stage.