### PR TITLE
Add details about TAC sponsorship expectations in TI lifecycle

### DIFF
--- a/process/project-lifecycle.md
+++ b/process/project-lifecycle.md
@@ -44,7 +44,7 @@ The OpenSSF Sandbox is the entry point for early stage Projects and has four goa
 * Provides project updates to OpenSSF Marketing Committee as requested.
 
 #### Project Support
-* Receives a TAC or WG sponsor for guidance on technical direction.
+* Receives a TAC or WG sponsor for guidance on technical direction. The sponsor also ensures the Project operates within the scope of the OpenSSF, adheres to the OpenSSF code of conduct, legal and IP policies, and reserves the right to consult with the TAC to raise any related concerns. Projects can reach out to the TAC if concerns about sponsor involvement arise.
 * Receives consideration as in-scope for any submission to an OpenSSF-managed conference or event.
 * Receives OpenSSF Code of Conduct Committee support.
 * Reserved space for project updates in OpenSSF newsletters.
@@ -77,7 +77,7 @@ Incubating projects represent maturing but not fully realized projects. Incubati
 * Begins to establish the appropriate governance that enables its sustainment for potential graduation.
 
 #### Project Support
-* Receives guidance on technical direction from TAC.
+* Receives guidance on technical direction from TAC and/or WG. The sponsor continues to ensure the Project operates within the scope of the OpenSSF, adheres to the OpenSSF code of conduct, legal and IP policies, and reserves the right to consult with the TAC to raise any related concerns. Projects can reach out to the TAC if concerns about sponsor involvement arise.
 * Receives consideration as in-scope for any submission to an OpenSSF-managed conference or event.
 * Receives OpenSSF Code of Conduct Committee support.
 * Receives infrastructure support (details determined by project leads and OpenSSF Budget Committee).
@@ -94,6 +94,9 @@ Incubating projects represent maturing but not fully realized projects. Incubati
 * Projects should be able to show adoption by multiple parties and adoption's value to the open source community and/or end users (may include adoption of beta/early versions) with the intent to showcase wide adoption by the project's consumers.
 * Projects must be aligned with the OpenSSF mission _and_ either be a novel approach for existing areas or address an unfulfilled need. It is expected that the initial code or specification developed by an OpenSSF WG be kept within their repository and will not function as a Project in its own right. Should the initial WG code or specification grow and mature that it warrants its own Project status, then it is subject to Sandbox entry requirements. It is preferred that extensions of an existing OpenSSF project collaborate with the existing project rather than seek a new project.
 * Projects must have documented, initial project governance.
+* If reporting directly to the TAC, the TAC sponsor and Project should decide on continued TAC sponsor engagement going forward. Continued engagement may include, but is not limited to:
+    * Project may consult about Project direction with TAC sponsor as needed throughout Incubating stage.
+    * TAC sponsor should continue to monitor Project activities, though regular meeting attendance is optional.
 
 #### Project Process: Sandbox to Incubation and direct entry to Incubation
 
@@ -115,7 +118,7 @@ Graduated projects signal the highest level of maturity for an OpenSSF project. 
 * Implements, practices, and refines mature development and release practices, such as adherence to semantic versioning, and having a declared policy for stable releases and backported fixes.
 
 #### Project Support
-* Receives guidance on technical direction from TAC.
+* Receives guidance on technical direction from TAC and/or WG.
 * Receives consideration as in-scope for any submission to an OpenSSF-managed conference or event.
 * Receives OpenSSF Code of Conduct Committee support.
 * Receives infrastructure support (details determined by project leads and OpenSSF Budget Committee).
@@ -134,6 +137,7 @@ Graduated projects signal the highest level of maturity for an OpenSSF project. 
 * Projects must be able to show a consistent release cadence.
 * Projects must have documented project governance and be able to demonstrate that governance in action.
 * When applicable, projects must have completed a security audit through a third party and addressed audit findings and recommendations.
+* If reporting directly to the TAC, TAC sponsor monitoring and consultation become optional.
 
 #### Project Graduation Process: Incubating to Graduation
 

--- a/process/sig-lifecycle.md
+++ b/process/sig-lifecycle.md
@@ -59,10 +59,10 @@ The SIG life cycle begins with interested contributors deciding to undertake thi
 
 ### SIG creation or change of lifecycle stage
 
-SIGs can be created and managed without formal approval from the TAC. However, for documentation purposes, group leads should record a lifecycle document when creating a SIG or changing a SIG's lifecycle stage. To this end, a SIG lead (or anyone in the case of an Archived SIG) creates a PR in this repository with the following changes:
+SIGs can be created and managed without a formal vote from the TAC. However, for documentation purposes, group leads should record a lifecycle document when creating a SIG or changing a SIG's lifecycle stage. To this end, a SIG lead (or anyone in the case of an Archived SIG) creates a PR in this repository with the following changes:
 
 * A new file in the `sig-lifecycle-documents` directory containing the information pertinent to the creation of the SIG or its lifecycle change. This file must be based on the template for the respective lifecycle stage in the `templates` directory. The `SIG_NAME_` prefix of the template must be replaced by the SIG name.
 
 * Modification of the table listing all SIGs in the [README](../README.md) of this repository by either updating the status field of the SIG in the table to the intended new lifecycle stage or by adding the SIG to the table in case of a SIG creation.
 
-Because no formal approval by the TAC is required the PR can be merged by any TAC or staff member.
+Because no formal vote by the TAC is required, the PR can be merged by any TAC or staff member without needing a majority of the TAC to approve the PR.

--- a/process/tac-member-R&Rs.md
+++ b/process/tac-member-R&Rs.md
@@ -6,6 +6,8 @@
 - Regularly attend TAC meetings, participate in discussions, voting, and ad-hoc meetings as needed to support Technical Initiatives
 - Approve, establish, structure, organize, and archive Technical Initiatives and associated policies and procedures 
 - Provide sponsorship and guidance to new Technical Initiatives that petition to join or be created within OpenSSF
+  - Sponsorship includes ensuring Technical Initiatives operate within the scope of the OpenSSF and adhere to OpenSSF code of conduct, legal and IP policies. Sponsors also reserve the right to consult with the rest of the TAC to raise any concerns about an Initiative's operations or conduct.
+  - If unable to continue fulfilling committed Technical Initiative sponsor role, another TAC member available to take over the sponsor role should be identified and transitioned into the role.
 - Participate in Technical Initiatives regularly to ensure alignment with the Technical Vision and MVSR of OpenSSF, and to identify any resource or funding requirements
 - Coordinate technical community matters related to the success of Technical Initiatives and the mission of the OpenSSF, including in support of end-users and ambassadors;
 

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -16,7 +16,7 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Proposal of scope for review by TAC
     * This is to help ensure limited overlap with existing WGs
 * Have at least 3 interested individuals from different organizations supporting the proposal
-* 1 TAC sponsor
+* 1 TAC sponsor to shepherd the WG through the Sandbox stage
     * TAC sponsor agrees to attend WG meetings regularly
     * TAC sponsor does not need to have a formal role in WG, e.g., chair
     * TAC sponsor requests TAC approval
@@ -29,6 +29,7 @@ Once the WG has further defined its goals and garnered enough support it can app
   * They should appear on the OpenSSF calendar
   * The WG should have a document with upcoming agendas and notes from past meetings
 * The WG should develop a charter or mission statement defining its goals.
+* The TAC sponsor ensures the WG operates within the scope of the OpenSSF, adheres to the OpenSSF code of conduct, legal and IP policies, and reserves the right to consult with the TAC to raise any related concerns.
  
 ## To become `Incubating`:
 
@@ -37,6 +38,9 @@ Once the WG has further defined its goals and garnered enough support it can app
     * For these, meeting notes (or ideally recordings) must be public
 * Have at least 5 contributors from at least 3 different organizations attending regularly
 * TAC will vote to approve or provide constructive guidance
+* TAC sponsor and WG chair(s) should decide on continued TAC sponsor engagement going forward. Continued engagement may include, but is not limited to:
+    * WG chair(s) may consult about WG direction with TAC sponsor as needed throughout the Incubating stage
+    * TAC sponsor should continue to monitor WG activities, though regular meeting attendance is optional.
 
 ## Once `Incubating`:
 
@@ -44,6 +48,7 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Deliver quarterly reviews to TAC
 * Complete and request TAC approval of [README.md](https://github.com/ossf/project-template/blob/main/README.md) which defines the WG's Charter and lists primary point(s) of contact from the TAC to the WG (this is often the WG Chair).
 * Meet on a regular cadence. Meetings are public, recorded, and on the calendar
+* The TAC sponsor continues to ensure the WG operates within the scope of the OpenSSF, adheres to the OpenSSF code of conduct, legal and IP policies, and reserves the right to consult with the TAC to raise any related concerns.
 * Have access to community resources (Zooms, YouTube channels, GitHub, Slack channels, etc.)
 * Can request funding/other resources (subject to TAC/GB approval)
     * NOTE: _At this time, funding and resources beyond collaboration tools have not been established in the OpenSSF. WGs should expect that their main resource is the community contributions they are able to recruit._
@@ -53,7 +58,8 @@ Once the WG has further defined its goals and garnered enough support it can app
 * Have received TAC approval of the README.md per `Incubating` requirements above
 * Have met at least 4 times over a period of at least 2 months since becoming `Incubating`
 * Have at least 5 contributors from at least 3 different organizations attending regularly as recorded in meeting minutes.
-* Request TAC approval. TAC will vote to approve or provide constructive guidance
+* Request TAC approval. TAC will vote to approve or provide constructive guidance.
+* TAC sponsor monitoring and consultation become optional.
 
 ## To remain `Graduated`:
 


### PR DESCRIPTION
This PR adds details about the scope and role of TAC sponsors in TIs. The main idea is to reduce TAC sponsor involvement as a TI matures through the lifecycle, while also allowing for each TI and TAC sponsor to flexibly determine the engagement. Edits to the TAC R&Rs reflect these details and also specify a process for transitioning between TAC sponsors, if need be. The added clarifications and details are based on the discussion in #263.

Fixes #263