### PR TITLE
Add infrastructure for TI reports to be submitted via github PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# OpenSSF TAC Changelog
+
+* 2024-05-22: Add infrastructure for TI reports to be submitted via github PR

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ The TAC is chartered as part of the [Open Source Security Foundation Charter](ht
 
 ## Technical Initiatives
 
-The governance of TIs is documented in [the process section](process). This section provides you with all the information about the different types of initiatives and how they are managed, as well as how to propose a new initiative. It also covers the different levels of maturity a TI can be in, the requirements that must be met to move up to the next level, as well as the benefits that come with each level. 
+The governance of TIs is documented in [the process section](process). This section provides you with all the information about the different types of initiatives and how they are managed, as well as how to propose a new initiative. It also covers the different levels of maturity a TI can be in, the requirements that must be met to move up to the next level, as well as the benefits that come with each level.
 
-The following Technical Initiatives have been approved by the TAC:
+The following Technical Initiatives have been approved by the TAC. You may learn more about their status through their [quarterly reports](TI-reports).
 
 ### Working Groups (WGs)
 

--- a/TI-reports/0000-quarterly-update-template.md
+++ b/TI-reports/0000-quarterly-update-template.md
@@ -1,0 +1,29 @@
+# YYYY Qn TI Name
+
+<mark>_Copy this template to the subdirectory for the current year and name the file `YYYY-Qn-TI-Name.md` (e.g., `2023-Q1-Best-Practices-WG.md`). Update the information above to change the `title` to the `YYYY Qn TI Name` (e.g., `2024 Q3 Best Practices WG`). Text between `<mark></mark>` are instructions. Please remove when section has been completed._
+</mark>
+
+## Overview
+
+<mark>_Required: Sum up the status, health of your TI, and the community in a few sentences. Consider this the TL;DR for the rest of the report. How is your community doing health-wise (e.g., is the number of active contributors increasing or decreasing) ? What are the latest news?
+</mark>
+
+## Activity #1 
+
+<mark>_Required: Replace the section title with the actual name (e.g., "Memory Safety SIG") and fill out each subsection. Repeat this section and subsections as necesssary for other activities.
+</mark>
+
+### Purpose
+
+### Current Status
+
+### Up Next
+
+### Questions/Issues for the TAC
+
+
+## Additional Information
+
+<mark>_Optional: Please provide any additional information that you feel would be useful for TAC to be aware._
+</mark>
+

--- a/TI-reports/README.md
+++ b/TI-reports/README.md
@@ -1,0 +1,15 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Technical Initiative (TI) Updates
+TI updates are:
+- used by the TAC to determine the health of a TI, including whether it should change state
+- provided to the Governing Board on a monthly basis in the TAC Update
+- used to highlight interesting updates to the Governing Board about the TIs
+- used to share interesting information with member companies by both the staff and TAC members
+- suggested as a point of reference for newcomers to determine if a TI would be worth joining based on information like the contributor diversity, as well as, the type of feature work that is ongoing within the TI
+
+# Instructions for Filing
+1. Copy the `0000-quarterly-update-template.md` file to the subdirectory for the current year and name the file `YYYY-Qn-TI-Name` (e.g., `2024-Q3-Best-Practices-WG.md`).
+1. Text between `<mark></mark>` are instructions. Please remove when section has been completed.
+1. Submit a Pull Request adding your report to the TAC repo.
+1. Once reviewed and approved by the TAC members, your PR will be merged.


### PR DESCRIPTION
This PR proposes a solution to issue #326 to submit TI reports via PRs rather than as issues. It is also entirely github based (no dependency on Google doc) although this could be combined if desired.
 