### PR TITLE
Improve election process and timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # OpenSSF TAC Changelog
 
+* 2024-05-24: Improve election process and timeline
 * 2024-05-22: Add TI funding request to TAC decision process doc (PR [#329](https://github.com/ossf/tac/pull/329))
 * 2024-05-22: Add infrastructure for TI reports to be submitted via github PR

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -3,7 +3,7 @@
 This document outlines the election process for the OpenSSF Technical Advisory Council (TAC) and Security Community Individual Representative (SCIR).
 
 
-## Voter Eligibility (Electorate) Self-Nomination Process
+## Voter Eligibility (Electorate) and Self-Nomination Process
 
 Any contributor to OpenSSF working groups, SIGs, or projects is eligible to participate in the election.
 Valid contributions include: commits or submitted pull requests via GitHub; public edits or comments on Google docs or other work products associated with OpenSSF; consistent participation in working groups; posting messages to any mailing list or on Slack; and beyond that any other form of positive engagement with OpenSSF activities.
@@ -39,7 +39,7 @@ The SCIR Candidate Self-Nomination Form will be sent out via email along with th
 
 The Election Process will be monitored by Election Officials, who
 * review nominees and confirm their eligibility,
-* approve the election timeline, and
+* approve the updated election timeline for the current year, and
 * review the ballot request form and validate voter eligibility.
 
 Election Officials are eligible community members who have volunteered to oversee and help ensure the integrity of the election process. By volunteering in this role, they recuse themselves from running for a TAC or SCIR position but they still are allowed to vote in the election.
@@ -56,25 +56,61 @@ The ballot will include the option to vote for both the TAC and SCIR.
 If the number of eligible nominees is less than the number of open positions, then all eligible nominees will be appointed and a second nomination phase for filling the remaining positions will be opened.
 If the number of eligible nominees equals the number of open positions, then those nominees will be elected unopposed.
 
+If one nominates themselves both for the TAC and SCIR elections, in case they are elected for the TAC they will be removed from the results of the SCIR election. The next candidate will then be elected for the SCIR position.
+
+Calls for volunteers, nominations, and registration and reminders will be sent broadly via email and on Slack to all Technical Initiatives and general forums.
+
+If an elected member steps down from their position more than 2 months before the end of their term the next candidate from the last election results will be offered the position.
+
+
 Questions related to the nomination and/or election process should be directed to [operations@openssf.org](mailto:operations@openssf.org).
 
 
-## Standard Election Timeline
+## Appointment Process
+
+The Governing Board will appoint three people from the list of TAC and SCIR Nominees excluding those who got elected. The Governing Board will be provided with the results of the election from the community so that they can ensure appropriate diversity of the TAC during their vote.
+
+
+## TAC Chair and Vice Chair Election
+
+After the results are announced the TAC members will elect a Chair and a Vice Chair with 1 week for nominations and 1 week for votes. Results may be announced when all votes are cast. The candidate with the most votes will serve as Chair and the second as Vice Chair. The Chair may however choose to swap seat with the Vice Chair if agreed by the Vice Chair.
+
+
+## Standard Nomination, Election, and Appointment Timeline
 
 The timeline in a standard election will follow the below format:
 
-10 months after the previous election, an election committee will be established by a call for volunteers. The volunteers have two weeks to begin the election process.
+About 10 months after the previous cycle, a committee of Election Officials will be established by a call for volunteers. The volunteers have 2 weeks to begin the election process.
 
-- Voter Ballot Request Period, and TAC and SCIR Self-Nomination Period - 2 weeks (concurrently)
-- Validation Period - 1 Week
+- Call for volunteers to serve as Election Officials - 2 weeks
+- Voter Registration and Self-Nomination Period - 2 weeks
+- Validation Period. Electorate can verify their registration and appeal if necessary. - 1 Week
 - Voting Period - 2 Weeks
 - Announcement of results - Day after the conclusion of the Voting Period
+- The elected members will be removed from the Governing Board appointment vote.
+- Appointment by the GB - 2 weeks
+- Announcement of results - Day after the conclusion of the Appointment Period
+- Election of the Chair and Vice Chair - 2 weeks
 
-### 2024 Timeline:
+### 2025 Timeline
 
- * Self-Nomination Period Starts: December 1
- * Self-Nomination Period Ends: December 15
- * Voting Starts: December 16
- * Voting Ends:  December 30
+ * September 30 - Send call for volunteers to serve as Election Officials in email and on Slack.
+ * October 7 - Send reminder of call for volunteers.
+ * October 14 - Self-Nomination and Voter registration period starts. Send call for nominees and eligible voters in email and on Slack.
+ * October 21 - Send reminder of call for nomination and registration.
+ * October 27 - Self-Nomination and Voter registration period ends at the End of Day US Pacific.
+ * October 28 - November 3 - Validation period.
+ * November 4 - Voting starts. Slate of candidates is formally announced. All registered voters are sent a ballot.
+ * November 17 - Voting ends at the End of Day US Pacific.
+ * November 18 - Results are announced, appointment starts. An email is sent to all GB members informing them of the vote, the results from the community election, and to look for a separate email with the ballot.
+ * November 23 - Send email reminder to GB members.
+ * December 1 - Voting ends at the End of Day US Pacific.
+ * December 2 - Results are announced, election of the Chair and Vice Chair starts
+ * December 17 - Chair and Vice Chair election results are announced
  * New members seated: January 1
- * The electorate can request a ballot by filling out this [Google form](https://forms.gle/7suYexAnPxndvX856).
+
+
+## Voter Registration form
+
+The electorate can request a ballot by filling out this [Google form](https://forms.gle/7suYexAnPxndvX856).
+


### PR DESCRIPTION
This PR clarifies several aspects of the election process related to the TAC and SCIR positions, namely:

* Clarifies when and how the appointment by the GB takes place
* Expands on the timeline with clear milestones
* Specifies how the TAC chair and vice chair are elected
* Specifies what happens when a member steps down
* Specifies what happens when one runs for both TAC and SCIR
* Specifies that calls for nominations, registration, and vote need to be sent broadly to all TIs and general forums via email and Slack

This closes PR #237 