### PR TITLE
[security_baseline.md] Alter "or" to "to" to denote a range

### DIFF
--- a/process/security_baseline.md
+++ b/process/security_baseline.md
@@ -227,7 +227,7 @@ Encrypting data in transit ensures that data transmitted over networks or betwee
     * Higher security: 3072 bits or 4096 bits
   * ECDSA (Elliptic Curve Digital Signature Algorithm):
     * Minimum recommended key length: 256 bits
-    * Higher security: 384 bits or 521 bits
+    * Higher security: 384 bits to 521 bits
   * Ed25519:
     * Fixed key length: 256 bits
 


### PR DESCRIPTION
Only NIST provides parameters for a 521 bit elliptic curve, others (e.g. ECC Brainpool) provide parameters for a 512 bit curve instead.