### PR TITLE
Update tac-member-R&Rs.md

### DIFF
--- a/process/tac-member-R&Rs.md
+++ b/process/tac-member-R&Rs.md
@@ -21,4 +21,4 @@
 - Annually elect a Chairperson who will preside over meetings, set the agenda for meetings, ensure meeting minutes are taken, and serve on the Governing Board as the TAC’s representative (the “TAC Representative”)
   
 - Time commitment: average 5+ hours per week
-- If unable to continue fulfilling committed Technical Initiative sponsor role, another TAC member available to take over the sponsor role should be identified and transitioned into the role.
+- Must inform the TAC if unable to continue fulfilling committed Technical Initiative sponsor role, so that a new sponsor can be identified and transitioned into the role.

--- a/process/tac-member-R&Rs.md
+++ b/process/tac-member-R&Rs.md
@@ -15,7 +15,7 @@
 - Participate in community events to raise awareness of OpenSSF tools and standards among project maintainers
 - Plans to engage & recruit community members 
 - Be available and responsive to OpenSSF staff for consulting early and often on operational plans,  issues and communications that have direct or indirect impact on OpenSSF community
-- Be available and responsive to leaders of “adjacent” initiatives (i.e. Alpha/Omega, GNU Toolchain) for early and oftern changes in strategy, roadmap, and press releases, etc
+- Be available and responsive to leaders of “adjacent” initiatives (i.e. Alpha/Omega, GNU Toolchain) for early and often changes in strategy, roadmap, and press releases, etc
 
 - TAC and Technical Initiative meetings shall be open, public meetings. For special circumstances, the TAC may hold meetings limited to the TAC voting representatives, invited guests, and LF staff
 - Annually elect a Chairperson who will preside over meetings, set the agenda for meetings, ensure meeting minutes are taken, and serve on the Governing Board as the TAC’s representative (the “TAC Representative”)

--- a/process/tac-member-R&Rs.md
+++ b/process/tac-member-R&Rs.md
@@ -4,13 +4,21 @@
 - Provide ongoing, technology-neutral technical guidance and sponsorship to Technical Initiatives throughout the respective lifecycle stages
 - Establish and drive an overall Technical Vision aligned with the Foundation's MVSR for the community 
 - Regularly attend TAC meetings, participate in discussions, voting, and ad-hoc meetings as needed to support Technical Initiatives
-- Approve, establish, structure, organize, and archive Technical Initiatives and associated policies and procedures 
+- Approve, establish, structure, organize, and archive Technical Initiatives and associated policies and procedures; identify gaps that require new Technical Initatives and advocate to close those gaps in the open source community; if a need for shared services that benefits stakeholders is identified by the community, communicate with the governing board to evaluate services on a case-by-case basis
+- Review and engage on open Github Issues and Pull Requests in advance of upcoming TAC meetings
 - Provide sponsorship and guidance to new Technical Initiatives that petition to join or be created within OpenSSF
   - Sponsorship includes ensuring Technical Initiatives operate within the scope of the OpenSSF and adhere to OpenSSF code of conduct, legal and IP policies. Sponsors also reserve the right to consult with the rest of the TAC to raise any concerns about an Initiative's operations or conduct.
-  - If unable to continue fulfilling committed Technical Initiative sponsor role, another TAC member available to take over the sponsor role should be identified and transitioned into the role.
-- Participate in Technical Initiatives regularly to ensure alignment with the Technical Vision and MVSR of OpenSSF, and to identify any resource or funding requirements
+ - Participate in Technical Initiatives regularly to ensure alignment with the Technical Vision and MVSR of OpenSSF, and to identify any resource or funding requirements
+- Regular dialogue with Technical Initative leads
+- Provide technical review of funding requests for Technical Initatives
 - Coordinate technical community matters related to the success of Technical Initiatives and the mission of the OpenSSF, including in support of end-users and ambassadors;
+- Participate in community events to raise awareness of OpenSSF tools and standards among project maintainers
+- Plans to engage & recruit community members 
+- Be available and responsive to OpenSSF staff for consulting early and often on operational plans,  issues and communications that have direct or indirect impact on OpenSSF community
+- Be available and responsive to leaders of “adjacent” initiatives (i.e. Alpha/Omega, GNU Toolchain) for early and oftern changes in strategy, roadmap, and press releases, etc
 
 - TAC and Technical Initiative meetings shall be open, public meetings. For special circumstances, the TAC may hold meetings limited to the TAC voting representatives, invited guests, and LF staff
 - Annually elect a Chairperson who will preside over meetings, set the agenda for meetings, ensure meeting minutes are taken, and serve on the Governing Board as the TAC’s representative (the “TAC Representative”)
+  
 - Time commitment: average 5+ hours per week
+- If unable to continue fulfilling committed Technical Initiative sponsor role, another TAC member available to take over the sponsor role should be identified and transitioned into the role.


### PR DESCRIPTION
As Crob and I were preparing for an update to the OpenSSF MVSR going into 2025, we found a list of TAC responsibilities. Adds here reflect some of what was in that document, as well as a few things I've been doing that I've seen us collectively doing that think should be communicated out prior to the election.