### PR TITLE
Add .gitvote file to activate GH voting on the TAC repo for TI funding request

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,0 +1,13 @@
+profiles:
+  default:
+    duration: 6w
+    pass_threshold: 70
+    periodic_status_check: "1 week"
+    allowed_voters:
+      teams:
+        - tac
+      exclude_team_maintainers: true
+    close_on_passing: true
+    announcements:
+      discussions:
+        category: announcements


### PR DESCRIPTION
The team with voting rights is [TAC](https://github.com/orgs/ossf/teams/tac)

If this team is not the correct people, a TI funding voting team could be established.

Fixes: https://github.com/ossf/tac/issues/384