### PR TITLE
Add security baseline reqs to project lifecycle templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # OpenSSF TAC Changelog
 
+* 2024-10-15: Add security baseline reqs to project lifecycle templates
 * 2024-08-20: Label Security Metric project as archived in README
 * 2024-08-15: Updated TI-Gives+Gets.md to clarify Logo entitlement based upon lifecycle stage vs. stage Badge usage [#373](https://github.com/ossf/tac/pull/373)
 * 2024-07-24: Added security baseline to incubating project responsibilities and graduated project entry requirements in project-lifecycle.md for for incubating projects [#363](https://github.com/ossf/tac/pull/363)

--- a/process/templates/PROJECT_NAME_graduation_stage.md
+++ b/process/templates/PROJECT_NAME_graduation_stage.md
@@ -41,7 +41,11 @@ When applicable, projects must have completed a security audit through a third p
 
 ### Security Baseline
 
-The project must meet the "[Security Baseline - To Become Graduated](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-graduated)" requirements.
+The project must meet all applicable Security Baseline requirements:
+ * [Security Baseline - Once Sandbox](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-sandbox)
+ * [Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-incubating)
+ * [Security Baseline - Once incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-incubating)
+ * [Security Baseline - To Become Graduated](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-graduated)
 
 ### Project References
 The project must provide a list of existing resources with links to the repository, website, a roadmap, contributing guide, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the project.

--- a/process/templates/PROJECT_NAME_graduation_stage.md
+++ b/process/templates/PROJECT_NAME_graduation_stage.md
@@ -41,11 +41,11 @@ When applicable, projects must have completed a security audit through a third p
 
 ### Security Baseline
 
-The project must meet all applicable Security Baseline requirements:
- * [Security Baseline - Once Sandbox](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-sandbox)
- * [Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-incubating)
- * [Security Baseline - Once incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-incubating)
- * [Security Baseline - To Become Graduated](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-graduated)
+The project meets all applicable Security Baseline requirements:
+ * [ ] [Security Baseline - Once Sandbox](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-sandbox)
+ * [ ] [Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-incubating)
+ * [ ] [Security Baseline - Once incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-incubating)
+ * [ ] [Security Baseline - To Become Graduated](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-graduated)
 
 ### Project References
 The project must provide a list of existing resources with links to the repository, website, a roadmap, contributing guide, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the project.

--- a/process/templates/PROJECT_NAME_graduation_stage.md
+++ b/process/templates/PROJECT_NAME_graduation_stage.md
@@ -39,6 +39,10 @@ Projects should harden their build systems in accordance with the SLSA Framework
 When applicable, projects must have completed a security audit through a third party and addressed audit findings and recommendations.
   * "link to results of security audit"
 
+### Security Baseline
+
+The project must meet the "[Security Baseline - To Become Graduated](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-graduated)" requirements.
+
 ### Project References
 The project must provide a list of existing resources with links to the repository, website, a roadmap, contributing guide, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the project.
 

--- a/process/templates/PROJECT_NAME_incubation_stage.md
+++ b/process/templates/PROJECT_NAME_incubation_stage.md
@@ -37,7 +37,9 @@ When contributing an existing Project to the OpenSSF, the contribution must unde
 
 ### Security Baseline
 
-The project must meet the "[Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/308c777124a05f1903301400653f1a7a944bd7be/process/security_baseline.md#baseline---to-become-incubating)" requirements.
+The project must meet all applicable Security Baseline requirements:
+ * [Security Baseline - Once Sandbox](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-sandbox)
+ * [Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-incubating)
 
 ### Project References
 The project should provide a list of existing resources with links to the repository, website, a roadmap, contributing guide, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the project.

--- a/process/templates/PROJECT_NAME_incubation_stage.md
+++ b/process/templates/PROJECT_NAME_incubation_stage.md
@@ -35,6 +35,10 @@ Project is integrated into the OpenSSF Scorecard
 When contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF). This step is only needed for the initial donation and only applicable here, if the project intends to join the OpenSSF Incubation stage.
   * "yes / no / not applicable. If yes, provide a link to the corresponding GitHub issue."
 
+### Security Baseline
+
+The project must meet the "[Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/308c777124a05f1903301400653f1a7a944bd7be/process/security_baseline.md#baseline---to-become-incubating)" requirements.
+
 ### Project References
 The project should provide a list of existing resources with links to the repository, website, a roadmap, contributing guide, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the project.
 

--- a/process/templates/PROJECT_NAME_incubation_stage.md
+++ b/process/templates/PROJECT_NAME_incubation_stage.md
@@ -37,9 +37,9 @@ When contributing an existing Project to the OpenSSF, the contribution must unde
 
 ### Security Baseline
 
-The project must meet all applicable Security Baseline requirements:
- * [Security Baseline - Once Sandbox](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-sandbox)
- * [Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-incubating)
+The project meets all applicable Security Baseline requirements:
+ * [ ] [Security Baseline - Once Sandbox](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---once-sandbox)
+ * [ ] [Security Baseline - To Become Incubating](https://github.com/ossf/tac/blob/main/process/security_baseline.md#security-baseline---to-become-incubating)
 
 ### Project References
 The project should provide a list of existing resources with links to the repository, website, a roadmap, contributing guide, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the project.


### PR DESCRIPTION
Although we added security baseline requirements to our project lifecycle these requirements have not been added to the project lifecycle templates. This PR fixes that.