### PR TITLE
Add TAC decision type for TI quarterly updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # OpenSSF TAC Changelog
 
+* 2024-10-22: Add TAC decision type for TI quarterly updates [#402](https://github.com/ossf/tac/pull/402)
 * 2024-08-20: Label Security Metric project as archived in README
 * 2024-08-15: Updated TI-Gives+Gets.md to clarify Logo entitlement based upon lifecycle stage vs. stage Badge usage [#373](https://github.com/ossf/tac/pull/373)
 * 2024-07-24: Added security baseline to incubating project responsibilities and graduated project entry requirements in project-lifecycle.md for for incubating projects [#363](https://github.com/ossf/tac/pull/363)

--- a/process/TAC-Decision-Process.md
+++ b/process/TAC-Decision-Process.md
@@ -35,10 +35,10 @@ Use the closest entry in the table that applies, selecting the first one if mult
 | Major  | Proposed changes to Charter, Technical Strategy, adopting a new TI, modifications to the TI Lifecycle process, or other cross-foundation changing proposals.  If approved, certain proposals will be moved to the Governing committee for review, move to GB. | 15d | 7 |
 | TI Lifecycle | Filed PRs for movement of TIs to new stages of the TI Lifecycle | 10d | 5 |
 | TI Funding Request | Issues opened by eligible OpenSSF Technical Initiative to petition for resources/funding. TAC review happens at the end of a quarterly submission period. If approved, recommended requests will be moved to the OpenSSF General Manager and the Governance Committee for dispensation. | 7d | 5 |
+| TI Update | Issues opened by TI leads to document their quarterly update to the TAC. | 7d | 5 |
 | Content |	A change to the process. Must include a changelog entry. |	72h |	3 |
 | Editorial |	A clarification to the process that does not change its requirements or meaning, beyond a simple fix. |	24h |	2 |
 | Nonspec | 	A change to a non-specification, non-blog page, beyond a simple fix. |	24h |	2 |
-| Blog | 	A new or updated blog post. (Do not mix with categories above.) | 	24h |	2 |
 | Fix |	A fix for obvious typos, broken links, and similar. |	0h |	1 |
 | Style |	A user-visible style or layout change. No content changes. |	0h |	1 |
 | Impl | 	A user-invisible change, such as editing a README or the repo configuration. |	0h | 	1 |


### PR DESCRIPTION
Since we're encouraging TIs to document their quarterly TAC updates via GitHub, this PR adds an explicit line to TAC-decision-process.md to document. 

This PR also removes the Blog decision since it doesn't apply to the TAC repo.