### PR TITLE
Update README Working Groups, Projects and SIGs lists and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ SIGs can be created and managed without formal approval from the TAC. The follow
 | Python Hardening       | https://github.com/ossf/wg-best-practices-os-developers/tree/main/docs/Secure-Coding-Guide-for-Python | Best Practices WG | TBD | TBD |
 | Security Baseline      | https://github.com/ossf/security-baseline              | Best Practices WG            | TBD | TBD |
 | SBOM Everywhere        | https://github.com/ossf/sbom-everywhere                | Security Tooling WG          | TBD | TBD |
-| OSS Fuzzing            | https://github.com/ossf/wg-security-tooling?tab=readme-ov-file#oss-fuzzing-sig | Security Tooling WG | TBD TBD |
+| OSS Fuzzing            | https://github.com/ossf/wg-security-tooling?tab=readme-ov-file#oss-fuzzing-sig | Security Tooling WG | TBD | TBD |
 
 ### Overview Diagrams
 

--- a/README.md
+++ b/README.md
@@ -51,15 +51,13 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 
 | Name                         | Repository                                              | Notes                                                                                                  | Status     |
 | ---------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------- |
-| Vulnerability Disclosures      | https://github.com/ossf/wg-vulnerability-disclosures    | [Meeting Notes](https://github.com/ossf/wg-vulnerability-disclosures/tree/main/docs/meeting-notes)     | [Graduated](process/wg-lifecycle-documents/Vuln_Disc_wg_graduation_stage.md) |
+| Vulnerability Disclosures      | https://github.com/ossf/wg-vulnerability-disclosures    | [Meeting Notes](https://docs.google.com/document/d/1AXkapzjZ-SxwcBN7rZeSstkzdapd3sbzfHDxz6A59Ic/edit)     | [Graduated](process/wg-lifecycle-documents/Vuln_Disc_wg_graduation_stage.md) |
 | Security Tooling               | https://github.com/ossf/wg-security-tooling             | [Meeting Notes](https://docs.google.com/document/d/1bFpHEbbEUf2rWiYXQY7cGg1HrmI9TqwaD8U_3Hi9A8I/edit) | Incubating |
-| Security Best Practices        | https://github.com/ossf/wg-best-practices-os-developers | [Meeting Notes](https://github.com/ossf/wg-best-practices-os-developers/blob/main/meeting-minutes.md)  | [Graduated](process/wg-lifecycle-documents/BEST_practices_wg_graduation_stage.md)  |
-| Metrics & Metadata             | https://github.com/ossf/wg-metrics-and-metadata         | [Meeting Notes](https://docs.google.com/document/d/14_ILDhSK3ymKqUTQeQBRgJKgfiy_ePoGZIe8s7p3K5E/edit)  | Incubating |
-| Securing Critical Projects     | https://github.com/ossf/wg-securing-critical-projects   | [Meeting Notes](https://docs.google.com/document/d/1GFslP6elYCx27TUitdigDr1gsOItYkL0Vq7hTB9y4Lo/edit)  | [Incubating](process/wg-lifecycle-documents/securing_critical_projects_incubating_stage.md) |
-| Supply Chain Integrity         | https://github.com/ossf/wg-supply-chain-integrity       | [Meeting Notes](https://docs.google.com/document/d/1xPs2sSbH3I9Ich7OyLOzl85oJshnK8Q6WoAgREE5-zA/edit)  | Incubating |
-| Securing Software Repositories | https://github.com/ossf/wg-securing-software-repos      | [Meeting Notes](https://docs.google.com/document/d/1-f6m442MHg9hktrbcp-4sM9GbZC3HLTpZPpxMXjMCp4/edit)  | [Graduated](process/wg-lifecycle-documents/Securing_software_repositories_graduation_stage.md) |
-| End Users                      | https://github.com/ossf/wg-endusers                     | [Meeting Notes](https://docs.google.com/document/d/1abI65H4pF5y8YtA2_TuDBAaI47v9mTfpr5mwVvccX_I/edit)  | Incubating |
-| Diversity, Equity, & Inclusion | https://github.com/ossf/wg-dei                          | [Meeting Notes](https://docs.google.com/document/d/1Ba_NJWWlsbTn2kVoBFpnMFMmdez9yJrHayocaxKkjaY/edit)  | Incubating |
+| Security Best Practices        | https://github.com/ossf/wg-best-practices-os-developers | [Meeting Notes](https://docs.google.com/document/d/1JY8FREBPCUUFpuv7-4B9EjeS2MLDpel0dbG5DFWrTns/edit)  | [Graduated](process/wg-lifecycle-documents/BEST_practices_wg_graduation_stage.md)  |
+| Securing Critical Projects     | https://github.com/ossf/wg-securing-critical-projects   | [Meeting Notes](https://docs.google.com/document/d/1j_efLVDXGoKgfHHZbJtpBxd_Gso1ghHBdK3NfEVc15o/edit)  | [Incubating](process/wg-lifecycle-documents/securing_critical_projects_incubating_stage.md) |
+| Supply Chain Integrity         | https://github.com/ossf/wg-supply-chain-integrity       | [Meeting Notes](https://docs.google.com/document/d/1moVFPn5pLi-uGs840_YBCrwdpHajU0ptFmlL4F9GryQ/edit)  | Incubating |
+| Securing Software Repositories | https://github.com/ossf/wg-securing-software-repos      | [Meeting Notes](https://docs.google.com/document/d/1HzA4M4toiExUYQAkuLqimy4EuuunHagUQ7rZKJDb1Os/edit)  | [Graduated](process/wg-lifecycle-documents/Securing_software_repositories_graduation_stage.md) |
+| Diversity, Equity, & Inclusion | https://github.com/ossf/wg-dei                          | [Meeting Notes](https://docs.google.com/document/d/1zGTOJdFVIMnixT3EFQ6_bbQ0iy7f4Z4TxhX9A5VY9TM/edit)  | Incubating |
 | AI/ML Security                 | https://github.com/ossf/ai-ml-security                  | [Meeting Notes](https://docs.google.com/document/d/1YNP-XJ9jpTjM6ekKOBgHH8-avAws2DVKeCpn858siiQ/edit)  | Incubating |
 
 ### Projects
@@ -77,10 +75,10 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 | OpenVEX | https://github.com/openvex | [Meeting Notes](https://docs.google.com/document/d/1C-L0JDx5O35TjXb6dcyL6ioc5xWUCkdR5kEbZ1uVQto/edit) | Vulnerability Disclosures WG | [Sandbox](process/project-lifecycle-documents/openvex_for_sandbox_stage.md) |
 | OSV Schema             | https://github.com/ossf/osv-schema               | [Meeting Notes](https://docs.google.com/document/d/1jzqhW9SK9QRA39fQz0RiAkvpRWB0xztt1TAFJEseTlA/edit?usp=sharing) | Vulnerability Disclosures WG   | TBD        |
 | Minder                 | https://github.com/mindersec/minder         | New project for inclusion                                                                                         | Security Tooling WG            | [Sandbox](process/project-lifecycle-documents/minder_sandbox_stage.md) |
-| Model signing          | TBD (to be created) | [Meeting Notes](https://docs.google.com/document/d/18oAsfhfKJurH-YTUFe520CAZS3lkORX1WnZmBv4Llkc/edit)  | AI/ML Security WG | [Sandbox](process/project-lifecycle-documents/model_signing_sandbox_stage.md) |
+| Model signing          | https://github.com/sigstore/model-transparency/blob/main/README.model_signing.md | [Meeting Notes](https://docs.google.com/document/d/18oAsfhfKJurH-YTUFe520CAZS3lkORX1WnZmBv4Llkc/edit)  | AI/ML Security WG | [Sandbox](process/project-lifecycle-documents/model_signing_sandbox_stage.md) |
 | Package Analysis       | https://github.com/ossf/package-analysis         | [Meeting Notes](https://docs.google.com/document/d/1GFslP6elYCx27TUitdigDr1gsOItYkL0Vq7hTB9y4Lo/edit) | Securing Critical Projects WG   | TBD        |
 | Package Feeds          | https://github.com/ossf/package-feeds            | [Meeting Notes](https://docs.google.com/document/d/1GFslP6elYCx27TUitdigDr1gsOItYkL0Vq7hTB9y4Lo/edit) | Securing Critical Projects WG   | TBD        |
-| Protobom | http://github.com/bom-squad/protobom | [Meeting Notes](https://docs.google.com/document/d/1bz2BBImzSnLRiBLrA5GehQ0ckW3Vs7Gmtt8R-Olm0QY/edit)  | Security Tooling WG | [Sandbox](process/project-lifecycle-documents/protobom_sandbox_stage.md) |
+| Protobom | https://github.com/protobom/protobom | [Meeting Notes](https://docs.google.com/document/d/1bz2BBImzSnLRiBLrA5GehQ0ckW3Vs7Gmtt8R-Olm0QY/edit)  | Security Tooling WG | [Sandbox](process/project-lifecycle-documents/protobom_sandbox_stage.md) |
 | Repository Service for TUF | https://github.com/repository-service-tuf/repository-service-tuf |  [Meeting Notes](https://docs.google.com/document/d/13a_AtFpPK9WO4PlAN6ciD-G1jiBU3gEDtRD1OUinUFY/edit)  | Securing Software Repositories WG | [Incubating](process/project-lifecycle-documents/repository_service_for_tuf_incubation_stage.md) |
 | S2C2F                  | https://github.com/ossf/s2c2f                    | [Meeting Notes](https://docs.google.com/document/d/10Q_VOvKsGaYJoK-5yJY4868mTkYZjEo-6xV6ghYS84k/edit#heading=h.1tv8gumsrtbf) | Supply Chain Integrity WG  | [Incubating](process/project-lifecycle-documents/s2c2f_incubation_stage.md)      |
 | SBOMit                 | https://github.com/sbomit                        | [Meeting Notes](https://docs.google.com/document/d/1-nHXMqvWNzgOxAq08O8Wu2BTHz0U60yBoAklrJAMaRc/edit?usp=sharing) | Security Tooling WG             | [Sandbox](process/project-lifecycle-documents/SBOMit_sandbox_stage.md)    |
@@ -98,12 +96,21 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 | Core Toolchain Infrastructure | https://git.coretoolchain.dev/     | TBD   | TBD    |
 | Alpha Omega                  | https://github.com/ossf/alpha-omega | TBD   | TBD    |
 
-### Special Interest Groups (SIGs) - *To Be Completed*
+### Special Interest Groups (SIGs)
 
 SIGs can be created and managed without formal approval from the TAC. The following is for information purpose only.
 
 | Name                       | Repository/Home Page | Notes                                                                                                 | Governing Org | Status     |
 | ---------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------- |---------- |
+| CVD Guides             | https://github.com/ossf/oss-vulnerability-guide        | Vulnerability Disclosures WG | TBD | TBD |
+| OpenVEX                | https://github.com/ossf/OpenVEX                        | Vulnerability Disclosures WG | TBD | TBD |
+| Education              | https://github.com/ossf/education                      | Best Practices WG            | TBD | TBD |
+| Memory Safety          | https://github.com/ossf/Memory-Safety                  | Best Practices WG            | TBD | TBD |
+| C/C++ Compiler Options | https://github.com/ossf/wg-best-practices-os-developers/tree/main/docs/Compiler-Hardening-Guides | Best Practices WG | TBD | TBD |
+| Python Hardening       | https://github.com/ossf/wg-best-practices-os-developers/tree/main/docs/Secure-Coding-Guide-for-Python | Best Practices WG | TBD | TBD |
+| Security Baseline      | https://github.com/ossf/security-baseline              | Best Practices WG            | TBD | TBD |
+| SBOM Everywhere        | https://github.com/ossf/sbom-everywhere                | Security Tooling WG          | TBD | TBD |
+| OSS Fuzzing            | https://github.com/ossf/wg-security-tooling?tab=readme-ov-file#oss-fuzzing-sig | Security Tooling WG | TBD TBD |
 
 ### Overview Diagrams
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 
 SIGs can be created and managed without formal approval from the TAC. The following is for information purpose only.
 
-| Name                       | Repository/Home Page | Notes                                                                                                 | Governing Org | Status     |
+| Name                       | Repository/Home Page | Governing Org                                                                                                 | Notes | Status     |
 | ---------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------- |---------- |
 | CVD Guides             | https://github.com/ossf/oss-vulnerability-guide        | Vulnerability Disclosures WG | TBD | TBD |
 | OpenVEX                | https://github.com/ossf/OpenVEX                        | Vulnerability Disclosures WG | TBD | TBD |


### PR DESCRIPTION
Following completion of an audit of our current Technical Initiatives to make the lists current, this update achieves the following:
- Fixes links to most recent meeting notes for several WGs
- Removes inactive WGs: end users and metrics
- Updates some github links in the projects list
- Adds current list of active SIGs

When time permits a future update will be made to review links for project meeting notes and add more data for SIGs where appropriate