### PR TITLE
Update TAC members following 2024 elections

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,4 +1,17 @@
 # Emeritus OpenSSF TAC members
 
 - [Dan Appelquist](https://github.com/torgo)
+- [Abhishek Arya](https://github.com/inferno-chromium)
+- [Aeva Black](https://github.com/AevaOnline)
+- [Josh Bressers](https://github.com/joshbressers)
+- [Phil Estes](https://github.com/estesp)
 - [Sarah Evans](https://github.com/sevansdell)
+- Jennifer Fernick
+- [Christopher Ferris](https://github.com/christo4ferris)
+- [Ryan Haning](https://github.com/rhaning)
+- [Luke Hinds](https://github.com/lukehinds)
+- [Dustin Ingram](https://github.com/di)
+- [Maya Kaczorowski](https://github.com/mayakacz)
+- Rao Lakkakula
+- [Dan Lorenc](https://github.com/dlorenc)
+- [Christopher "CRob" Robinson](https://github.com/SecurityCRob)

--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,0 +1,4 @@
+# Emeritus OpenSSF TAC members
+
+- [Dan Appelquist](https://github.com/torgo)
+- [Sarah Evans](https://github.com/sevansdell)

--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@ The TAC [meetings minutes](https://docs.google.com/document/d/1-zrtagRnPd75TDT1z
 
 Meetings are also recorded and posted to the [OpenSSF YouTube channel](https://www.youtube.com/channel/UCUdhiXNEBEayowJXY_v7AXQ/).
 
-
 ## TAC Members
 
 | Name             | Position | Email                          | Organization | Term                      |
 | ---------------- | :--------: | ------------------------------ | ------------ | --------------------------|
 | Arnaud J Le&nbsp;Hors | Vice Chair | lehors@us.ibm.com              | IBM          | January 2024 - December 2025 |
-| Bob Callaway     |  | bcallaway@google.com           | Google       | January 2024 - December 2024\*  |
-| Dan Appelquist   |  | dan@torgo.com                  | Samsung         | January 2024 - December 2024 |
-| Michael Lieberman|  | mike@kusari.dev                | Kusari       | January 2024 - December 2024 |
-| Zach Steindler   | Chair | steiza@github.com         | GitHub       | January 2024 - December 2024 |
+| Bob Callaway     |  | bcallaway@google.com           | Google       | January 2024 - December 2026 |
+| Michael Lieberman|  | mike@kusari.dev                | Kusari       | January 2024 - December 2026 |
+| Zach Steindler   | Chair | steiza@github.com         | GitHub       | January 2024 - December 2026 |
 | Marcela Melara   |  | marcela.melara@intel.com       | Intel        | January 2024 - December 2025 |
-| Sarah Evans      |  | sarah.evans@dell.com           | Dell         | January 2024 - December 2024\* |
 | Jautau "Jay" White || jaywhite@microsoft.com         | Microsoft    | January 2024 - December 2025 |
+| Stephen Augustus | | openssf@auggie.dev | Independent | January 2025 - December 2025\* |
+| Georg Kunz | | georg.kunz@ericsson.com | Ericsson | January 2025 - December 2025\* |
+| Michael Scovetta | | michael.scovetta@microsoft.com | Microsoft | January 2025 - December 2025\* |
 
-NOTE: \* marked entries denote OpenSSF Governing Board appointed members, others are community elected. There is currently 1 vacant Governing Board appointed seat.
+*NOTE: `*`-marked entries denote TAC members appointed by the OpenSSF Governing Board; all other members are community-elected.*
 
 ## Charter
 


### PR DESCRIPTION
Add community-elected TAC members:

- Bob Callaway, Google
- Michael Lieberman, Kusari
- Zach Steindler, GitHub

ref: https://lists.openssf.org/g/openssf-tac/message/797

Add GB-appointed TAC members:

- Stephen Augustus, Independent — @justaugustus
- Georg Kunz, Ericsson — @gkunz
- Michael Scovetta, Microsoft — @scovetta

ref: https://lists.openssf.org/g/openssf-tac/message/799

The following TAC members are now emeriti:

- Dan Appelquist
- Sarah Evans

cc: @ossf/tac 