### PR TITLE
Update meeting notes for 2025 and add 2024 archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you need support in any part of the process, please email [operations@openssf
 
 ## Meetings
 
-The TAC [meetings minutes](https://docs.google.com/document/d/1-zrtagRnPd75TDT1zRxrtxE9SpMIBJdPmaolaw4woQA/) are online and appear on the [OpenSSF Community Calendar](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
+The TAC [meetings minutes](https://docs.google.com/document/d/1EieWyhKntZ7BzaZS97-BOybfMTUT4sZ72ViXq8QyYWs) are online and appear on the [OpenSSF Community Calendar](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
 Meetings are also recorded and posted to the [OpenSSF YouTube channel](https://www.youtube.com/channel/UCUdhiXNEBEayowJXY_v7AXQ/).
 

--- a/minutes/2024.md
+++ b/minutes/2024.md
@@ -1,0 +1,2403 @@
+# 2024 OpenSSF TAC Meeting Notes
+
+| ![][image1]:  [Repo](https://github.com/ossf/tac)  | [Discussions](https://github.com/ossf/tac/discussions) | 📅:  Occurs every 2 weeks🕗:  8:00a PT/11:00a ET ![][image2]:  [LFX  Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/94234355704?password=939d8506-7e58-4072-89e3-6b59259ee9db) |
+| :---- | :---- |
+| 📧📭:  [OpenSSF](https://lists.openssf.org/g/openssf-tac)\* (Mailing List) \* Join the Mailing List to receive the calendar meeting invite. | ![][image3]:  [OpenSSF](https://www.youtube.com/channel/UCUdhiXNEBEayowJXY_v7AXQ/) |
+
+## [Antitrust Policy Notice](http://www.linuxfoundation.org/antitrust-policy)
+
+## Code of Conduct
+
+All participants in OpenSSF meetings are subject to the OpenSSF Code of Conduct. See: [https://openssf.org/community/code-of-conduct/](https://openssf.org/community/code-of-conduct/)
+
+## Meeting Notes
+
+* Notes are in reverse chronological order. Most recent meeting at the top.  
+* For meetings prior to 2024 see the [older meeting notes](https://docs.google.com/document/d/1706vJpuyq4NpHpVYsOTeU90j5RpoJREX7MRlhAo-CW4/edit#heading=h.1fob9te).
+
+## Future Agenda Items
+
+This is a list of proposed agenda items. Anyone can propose one here for small-ish items or to discuss with the group when to schedule and we’ll add to meetings on-the-fly as time permits. Please add new items to the END of this list of proposed agenda items
+
+* 
+
+Working Group / Project Report Schedule 
+
+* Report templates: [slides](https://docs.google.com/presentation/d/16RhFJQgPP3E9u6aLQOjZ0HofuD0-X0Pg589VklvkJ24/edit?usp=sharing) & [email](https://lists.openssf.org/g/openssf-wg-best-practices/message/196)
+
+### 2024 Schedule
+
+| TAC Meeting Date | Working Group, Top-Level Project or Associated Project | WG Lead |
+| ----: | :---- | :---- |
+| ~~Jan 9~~ | ~~AI / ML WG, SOSS Updates~~  | ~~Mihai Maruseac and Jay White,  SOSS \-~~  |
+| ~~Jan 23~~  | ~~Metrics and Metadata, Securing Critical Projects, SOSS Updates~~  | ~~Michael Scovetta, Amir Montazery and Jeff Mendoza, SOSS \- Zach & CRob~~ |
+| ~~Feb 6~~ | ~~Supply Chain Integrity~~ | ~~Isaac Hepworth~~  |
+| ~~Feb 20~~ | ~~Security Tooling,Securing SW Repos~~ | ~~Ryan Ware~~, ~~Dustin Ingram~~ |
+| ~~Mar~~ 5 | ~~Sigstore,~~ ~~Vulnerability Disclosures~~ | ~~Luke Hinds,~~ ~~CRob~~ |
+| ~~Mar 19~~ | ~~Alpha-Omega, CTI, DEI~~ | ~~Mike Scovetta, David Edelsohn & Carlos O’Donnell, Jay White~~ |
+| ~~Apr 2~~ | ~~Best Practices, End Users~~ | ~~CRob, Jon Meadows~~ |
+| ~~Apr 16~~ | ~~**CANCELED \-** *(Overlaps with OSS North America)*~~ |  |
+| ~~Apr 30~~ | ~~AI / ML WG, SOSS Updates~~  | ~~Mihai Maruseac and Jay White,~~  |
+| ~~May 14~~ | ~~Metrics and Metadata~~, ~~Securing Critical Projects~~ | ~~Luigi Gubello~~, ~~Amir Montazery and Jeff Mendoza~~ |
+| ~~May 28~~ | ~~Supply Chain Integrity~~ | ~~Isaac Hepworth~~  |
+| ~~Jun 11~~ | ~~Security Tooling,Vulnerability Disclosures, Securing SW Repos~~ | ~~Ryan Ware, CRob, Zach Steindler~~ |
+| ~~Jun 25~~ | ~~**CANCELED**~~ |  |
+| ~~July 9~~ | ~~Alpha-Omega, Sigstore~~ | ~~Mike Scovetta,Luke Hinds~~ |
+| ~~July 23~~ | ~~CTI, DEI~~ | ~~David Edelsohn & Carlos O’Donnell, Jay White,~~  |
+| ~~Aug 6~~ | ~~**CANCELED**~~ |  |
+| ~~Aug 20~~ | ~~Best Practices, End Users~~ | ~~CRob, Jon Meadows~~ |
+| ~~Sep 3~~ | ~~AI / ML WG, SOSS Updates~~  | ~~Mihai Maruseac and Jay White,~~  |
+| ~~Sep 17~~ | **~~CANCELED~~** | ~~OSS \-EU~~ |
+| ~~Oct 1~~ | ~~Metrics and Metadata, Securing Critical Projects~~ | ~~Luigi Gubello, Amir Montazery and Jeff Mendoza~~ |
+| ~~Oct 15~~ | ~~Supply Chain Integrity~~ | ~~Isaac Hepworth~~  |
+| ~~Oct 29~~ | ~~Securing SW Repos, Security Tooling~~ | ~~Zach Steindler, Ryan Ware~~ |
+| ~~Nov 12~~ | Vulnerability Disclosures, Alpha-Omega ***(Meeting Canceled)*** | Madison Oliver, Mike Scovetta |
+| **~~Nov 26~~** | CTI, DEI, Sigstore ***(Meeting Canceled)*** | David Edelsohn & Carlos O’Donnell, Jay White, Luke Hinds |
+| ~~Dec 10~~ | ~~*No Project Updates*~~  |  |
+| **Dec 24** | **NO MEETING** |  |
+| Jan 07, 2025 | Best Practices, ~~End Users~~ | Georg \+ Avishay, ~~Jon Meadows~~ |
+| Jan 21, 2025 | AI / ML WG, SOSS Updates  | Mihai Maruseac and Jay White,  |
+| Feb 04, 2025 | Securing Critical Projects | Amir Montazery and Jeff Mendoza |
+| Feb 18, 2025 | Security Tooling, Supply Chain Integrity | Ryan Ware, Isaac Hepworth  |
+
+Housekeeping Table (Working Groups)
+
+| WG | Charter | Groups.io Mailing List | Chair | TAC Check-In | Drive Folder |
+| :---: | :---: | :---: | ----- | :---: | :---: |
+| Best Practices | Adopted [Issue 103](https://github.com/ossf/wg-best-practices-os-developers/issues/103) | [Link](https://lists.openssf.org/g/openssf-wg-best-practices) | @Christopher Robinson  | 2023: Mar 7 May 30 Sept 5 Nov 28 |  |
+| Metrics and Metadata | [Requires TAC Approval](https://github.com/ossf/wg-identifying-security-threats/blob/main/CHARTER.md) | [Link](https://lists.openssf.org/g/openssf-wg-metrics-and-metadata) | @Michael Scovetta  [Luigi Gubello](mailto:luigi.gubello@gmail.com) | 2023: Mar 21 June 13 Sept 19 Dec 12 |  |
+| Securing Critical Projects | [In Review (PR\#58)](https://github.com/ossf/wg-securing-critical-projects/pull/58) | [Link](https://lists.openssf.org/g/openssf-wg-securing-crit-prjs) | @Amir Montazery and @Jeff Mendoza | 2023: Mar 21 June 13 Sept 19 Dec 12 |  |
+| Security Tooling | [Adopted April 4 2021](https://github.com/ossf/wg-security-tooling/blob/main/CHARTER.md) | [Link](https://lists.openssf.org/g/openssf-wg-security-tooling) | @Josh Bressers | 2023: April 4 July 11 Oct 3 |  |
+| Supply Chain Integrity | [In Review (PR \#53)](https://github.com/ossf/wg-supply-chain-integrity/pull/53) | [Link](https://lists.openssf.org/g/openssf-supply-chain-integrity) | [Isaac Hepworth](mailto:isaach@google.com) and [Melba.Lopez@ibm.com](mailto:Melba.Lopez@ibm.com) and Jay White | 2023: April 4 July 11 Oct 3 |  |
+| Vulnerability Disclosures | Adopted [Issue 120](https://github.com/ossf/wg-vulnerability-disclosures/issues/120) | [Link](https://lists.openssf.org/g/openssf-wg-vul-disclosures) | Madison Oliver | 2023: April 18 July 25 Oct 17 |  |
+| TAC |  | [Link](https://lists.openssf.org/g/openssf-tac) | Chair: CRob  Vice Chair: Arnaud Le Hors |  |  |
+| Securing Software Repos | [Adopted April 13 2022](https://github.com/ossf/wg-securing-software-repos/blob/main/CHARTER.md) | [Link](https://lists.openssf.org/g/openssf-wg-securing-software-repos)   (new\!) | Dustin Ingram and Zach Steindler  | 2023: April 18 July 25 Oct 17 | [Link](https://drive.google.com/drive/folders/19rkJhu88XanJQUsoRXu8GJyjojcv-yeR) |
+| End Users |  | [Link](https://lists.openssf.org/g/openssf-wg-endusers)  | Chair: Jon Meadows Vice Chair: Jacques Chester | 2023: Mar 7 May 30 Sept 5 Nov 28 |  |
+| [Sigstore](https://www.sigstore.dev/) | Project | [Link](mailto:sigstore-dev@googlegroups.com)  | Luke Hinds, Priya Wadhwa, Bob Callaway, Trevor Rosen, Santiago Torres  | 2023: May 2 Aug 8 Oct 31 |  |
+| AI/ML WG |  |  | Mihai Maruseac, Jay White |  |  |
+| DEI WG |  |  | Jay White, Marcela Melara, Yesenia Yser |  |  |
+
+| Associated Directed Fund / SIF | Type | Charter | Groups.io Mailing List | Leads | TAC Check-In |
+| :---- | :---- | :---- | ----- | :---- | :---- |
+| [Alpha-Omega](https://openssf.org/community/alpha-omega/) | SIF |  | [Link](mailto:alpha-omega-announcements@lists.openssf.org)  | Michael Scovetta (Microsoft); Bob Callaway (Google)Henri Yandell (AWS) | 2023: May 2 Aug 8 Oct 31 |
+| CTI | ADF |  | [cti-tac@lists.linuxfoundation.org](mailto:cti-tac@lists.linuxfoundation.org) [Link](https://subspace.kernel.org/lists.linuxfoundation.org.html) | OpenSSF Staff \+  Carlos O'Donell; David Edelsohn | 2024: March 19 July 23 Oct 29 |
+
+## Meetings
+
+# **2024-12-10**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+|  x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+|  x | Bob Callaway (Google, **Sigstore, A-O**, **TAC**)   | he/him | bobcallaway |
+|  x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+|  x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Co-Lead, TAC**) | he/him | camaleon2016 |
+|  x | Marcela Melara (Intel, **DEI WG Co-lead**, **TAC**) | she/her | marcelamelara |
+|  x  | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+|  x | Zach Steindler (GitHub,**TAC Chair**) | he/him | steiza |
+|  x | David Edelsohn (**CTI**) | he/him | edelsohn |
+|  x | Ryan Ware (**Tooling WG Lead**) | he/him | ware |
+|  |  |  |  |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Angelah Liu (LF) | she/her |  |
+| x | CRob (LF) | he/him | SecurityCrob |
+| x | David A. Wheeler (LF) | he/him | david-a-wheeler |
+| x | Jeff Diecks (LF) | he/him | GeauxJD |
+| x | Kris Borchers (LF) | he/him | kborchers |
+| x | Naomi Washington (LF) | she/her | Naomi-Wash |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Riaan Kleinhans (LF) | he/him | riaankleinhans |
+| x | Sally Cooper (LF) | she/her |  |
+| x | Todd Moore (LF) | he/him |  |
+|  |  |  |  |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+| x | Evan Anderson (Stacklok) | he/him | evakanderson |
+| x | Madison Oliver (GitHub) | she/her | Taladrane |
+| x | Stacey Potter (Stacklok) | she/her | staceypotter |
+| x | Cristian Urlea (University of Glasgow) | he/him | cristianurlea |
+| x | Xavier Rene-Corail (GitHub) | he/him | xcorail |
+| x | Will Enck (NCSU) |  |  |
+| x | Karen Bennet (IEEE) | she/her |  |
+| x | Will Enck (NCSU) |  |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe \- Riaan & Reden  
+* Determine TAC quorum \- Quorum was established for the conduct of business.   
+* Zach gave a welcome noting that TAC elections are still running, and we’re currently in the process of the GB TAC-appointed elections. Voting was sent on Monday and will close Sunday, December 15\.   
+* Update homework/outstanding ARs  
+  *   
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Best Practices \- Georg \+ Avishay   
+    * The project updates for the *Best Practices WG* have been moved to the next TAC meeting. Will happen in 2025\.  
+        
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * Thank you 2024 TAC\!  
+  * 2024 Q4 Funding Results  
+    * Technical Writer for Package Yanking Guidance: [\#414](https://github.com/ossf/tac/issues/414)  
+    * 2025 RSTUF Cloud/k8s deployment costs for tests, demo and validations: [\#417](https://github.com/ossf/tac/issues/417)  
+      * Riaan \- send these approvals to the GM for final approval.   
+  * \[Riaan\] Project proposals via GitHub issues: [\#416](https://github.com/ossf/tac/pull/416)  
+    * \[Riaan\] \- discussed efforts to simplify the onboarding process for projects, specifically mentioning a pull request to create onboarding templates. The process involves two steps: first, the TAC approves the project, and then the LF handles the onboarding via PCC, typically completed within 24 hours. The main obstacle is usually legal review. Riaan emphasizes the importance of streamlining the process and aims to improve how projects are onboarded to make it faster and easier.  
+    * Due to a poor end user experience, Riaan has opened a PR to create a GHI template to onboard new projects.  
+      * Presented a more streamlined process that includes once a GHI has been submitted, they are sent LF Project Governance documents for their review and redline.  
+      * It was clarified that what Riaan is suggesting happens post-TAC approval \- naming needs to be fixed from project proposal as that’s not what it is referring to. It should probably be something like “creation project request” rather than proposal.  
+      * Suggested: Add a question to link back to PR so potential projects don’t have to complete double work.   
+  * \[Riaan\] \[IP policy and license review\] Vuln-Reach Sandbox Project Entry [\#387](https://github.com/ossf/tac/issues/387)  
+    * Reach out to Louis Lang via GH & email, no response yet.
+
+* Issues for VOTE (list issue \#)  
+  * Global Cybersecurity Policy Working Group \- Sandbox: [\#418](https://github.com/ossf/tac/pull/418)  
+    * CRA was launched this year and there are implications to open source developers and stewards. CRob noted that few members are onsite for the CRA workshop discussing how open source needs to prepare in the next 3 years to meet the requirements of the CRA.   
+    * Suggested: Create a working group hosted under OpenSSF to caretake the activities to prepare the ecosystem, developers, etc.   
+      * Steps: Identifying chairs, create a stream around tooling and processes, create standardization track, identify areas where the standard model is needed.  
+      * CRob will own creating the GH repos, and driving the creation of this working group  
+      * The proposal seeks TAC approval to create a new working group focused on ecosystem awareness, training, tooling, processes, and global standards, leveraging Linux Foundation capabilities and community specs, with plans to establish governance, resources, and leadership for long-term success.  
+      * \[Dan\] \- supports creating a lightweight working group with integrated SIGs, meeting within the main group initially to minimize complexity, while acknowledging the need for SIGs and expressing intent to actively participate.  
+      * \[Jay\]- Is the goal to create standards that address current requirements like the CRA and Cyber EO while also anticipating and preparing for future regulations and policies?  
+      * \[CRob\] \- The standard creation is part of it. It is not the sole objective.  
+      * \[Bob Calloway\] \- Is this working group aiming to influence others to standardize their developments, or will it take an authoritative role in deciding what should become a standard and drive the community toward that goal?  
+      * \[CRob\] \- The working group will balance advocating for existing community specs and collaborating on new standards to address gaps. In the short term, the focus is on identifying international standards and best practices to help manufacturers meet compliance obligations, particularly for the CRA. The group plans to work with Jory, Sean, and the JDF Foundation to navigate the standardization process, involving partnerships with teams like SLSA and potentially hiring support for documentation and facilitation.  
+      * \[Marcela\] \- What is the potential impact of standardizing evolving community specs like SLSA on their ongoing development? How does the process handle updates or new versions once something becomes an ISO standard?  
+      * \[Crob\] \- SLSA could be a strong candidate for standardization, but more research is needed. While standardizing introduces stricter update processes and requires periodic amendments, Jory and Sean can guide the group through this. Collaboration with JDF and technical initiatives will help outline commitments and necessary adjustments for this approach.  
+      * \[Arnaud\] \- Standardizing a spec doesn’t freeze its evolution. The spec can continue to evolve independently, with updated versions periodically submitted to the standards body in a parallel process. This is a common and manageable practice.  
+          
+    * Discussion ensued re: the need for 3 SIGs mentioned on the GHI. It was   
+    * Discussion ensued around standards  
+      * Standards is just a portion of the larger goal of this working group.  
+      * A question was posed is this group to be an influential party only for creating/driving suggestions. CRob noted that it is a little of both. In short term \- for manufacturers \- we are to develop standards on what they need to do to be compliant. Work with JDF (Jory and Shawn) to develop these standards. (1. Identify what is useful for the community, 2\. Talk to the teams (ex. SLSA) and discuss commitments and collaborations)  
+      * Daniel Appelquiest would that the role as TAC sponsor for the initiative \#418
+
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * Feedback on on 2024 funding process for making 2025 funding process: [\#419](https://github.com/ossf/tac/issues/419)  
+    * \[Zach\] \- The funding review schedule is undecided, with options including quarterly, bi-monthly, or rolling reviews. While only about a dozen requests were received last year, an increase is anticipated. If quarterly reviews continue, the next cycle would likely be in late February or early March, which is the tentative timeline for responses to current funding requests.  
+    * \[CRob\] \- It would be helpful to have the funding review schedule ready by early January so it can be shared during the next working group lead call, allowing leads to begin soliciting requests.  
+    * \[Riaan\] \- proposes adopting a rolling funding schedule for next year to expedite the allocation and spending of funds. This approach addresses concerns from the governing board about slow fund usage and aims to ensure projects can begin sooner without unnecessary delays. The goal is to allocate funds promptly as requests come in to avoid blockers and speed up the process.  
+    * \[Michael\] \- agrees with adopting a rolling funding schedule, given the current low volume of requests. If a backlog were to develop in the future, they could reconsider a more structured schedule (e.g., monthly or quarterly). For now, a rolling schedule makes sense to keep things moving smoothly.  
+    * \[Bob\] \- disagrees with the rolling schedule, arguing that the issue is not the process but rather a lack of proposals. They believe batching the proposals will help drive discussions around budget allocation, ensuring that funds aren’t spent too quickly in one go, leaving nothing for later.  
+    * Discussion ensued on how to make the process better? Asked the TAC to think about this and provide feedback.   
+      * A few TAC members noted that there isn’t an issue with the current process.   
+    * 2025 Schedule   
+      * Default to be quarterly  
+        * It was flagged that community members are having to wait too long with once a quarter  
+      * Suggested: rolling schedule due to the GB wanting to spend the money  
+        * It was noted that there isn’t a process issue but a demand issue (we’re not getting enough proposals).   
+    * Action: Vote on this in January 2025  
+        
+  * Automation solution for GitHub processes that need a PAT: [\#420](https://github.com/ossf/tac/issues/420)  
+    * \[Zach\] \- explained the operational burden faced by open-source projects like Minder and Gituf, where maintainers must periodically provision secrets for their release pipelines to function. He asked Evan Anderson to give a more accurate explanation or pitch about the issue, rather than continuing with their own attempt.  
+    * \[Evan\] \- explained the process for releasing the Minder binary to the Windows ecosystem through the winget-pkgs repository. Asked if OpenSSF has common infrastructure for managing these types of credentials, with the ideal solution being an automation account ("bot") that stores credentials in a shared-secrets solution like 1Password, allowing access for maintainers and OpenSSF staff.  
+    * \[CRob\] \- noted that the Linux Foundation uses 1Password internally but is unsure about the privileges projects have to access it. He suggested that they and Riaan could investigate further to determine if this could be an option for managing credentials for the projects.  
+    * \[Marcela\] \- Does that touch on the security baseline? I guess is there anything on the security baseline that needs to be adjusted for this one pass access?  
+    * \[CRob\] \- will review and advise the group
+
+* Updates on older matters   
+  * 
+
+
+* AOB  
+  * None this week
+
+# **2024-11-26** *\- Canceled (2 days before US Thanksgiving)*
+
+**Note:** WGs / Tis  scheduled to provide updates on the canceled date are requested to post them on [GitHub](https://github.com/ossf/tac/tree/main/TI-reports). Any questions or discussions can continue asynchronously.  
+ 
+
+* CTI \- David Edelsohn & Carlos O’Donnell  
+* DEI – Jay White  
+* Sigstore – Luke Hinds
+
+
+# **2024-11-12** *\- Canceled (Overlap with the [KubeCon NA event](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/))*
+
+**Note**: WGs / Tis  scheduled to provide updates on the canceled date are requested to post them on [GitHub](https://github.com/ossf/tac/tree/main/TI-reports). Any questions or discussions can continue asynchronously.  
+ 
+
+* Vulnerability Disclosures v- Madison Oliver  
+* Alpha-Omega – Michael Scovetta
+
+# **2024-10-29**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | Bob Callaway (Google, **Sigstore, A-O**, **TAC**)   | he/him | bobcallaway |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Co-Lead, TAC**) | he/him | camaleon2016 |
+| x | Marcela Melara (Intel, **DEI WG Co-lead**, **TAC**) | she/her | marcelamelara |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Sarah Evans (Dell Technologies, **GC,** **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC Chair**) | he/him | steiza |
+| x | Ryan Ware (**Tooling WG Lead**) | he/him | ware |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Angelah Liu (LF) | she/her |  |
+| x | David A. Wheeler (LF) | he/him | david-a-wheeler |
+| x | Jeff Diecks (LF) | he/him | GeauxJD |
+| x | Naomi Washington (LF) | she/her | Naomi-Wash |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Riaan Kleinhans (LF) | he/him | riaankleinhans |
+| x | Sally Cooper (LF) | she/her |  |
+| x | Kris Borchers (LF) | he/him | kborchers |
+| x | Aeva Black (CISA) | they/them | AevaOnline |
+| x | Evan Anderson (Stacklok) | he/him | evakanderson |
+| x | Georg Kunz(Ericsson) | he/him | gkunz |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Dan A.  
+* Determine TAC quorum  
+  *  👍  
+* Update homework/outstanding ARs  
+  *   
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Securing SW Repos \- Zach Steindler  
+    * [https://github.com/ossf/tac/pull/401](https://github.com/ossf/tac/pull/401)   
+    * This is a group of OSS repos: NPM, NuGet, RubGems, PyPI, Homebrew, etc., The goal is to help these systems to be more secure. Currently mostly language-level, but would like to add system-level. We do have homebrew participating.  
+    * Main development: Working on trusted publishing. PyPI & RubyGems worked on the spec. “Trusted Publishing for All Package Repositories” [https://repos.openssf.org/trusted-publishers-for-all-package-repositories](https://repos.openssf.org/trusted-publishers-for-all-package-repositories)  
+    * If you have an automated build process for an open source package you should have a secure way to push to the package repository… PyPI and RubyGems implemented “trusted publishing” OIDC token.. Uses the identity of the build itself… Implementation under way across ecosystems.In the working group, we also have signing package repository indexes… working with rubygems and pypi… We’re also writing up guid  
+    * ance for package repositories on binary transparency… Recording the has of a package first time and then dist on a write-only ledger.  
+    * Collaboration happening with sigstore…  cpython to move to sigstore signatures… deprecating gpgkeys… interesting opportunity : all the python packages could also start signing those packages with sigstore bundles…  
+    * Dan: ref SWAG and work on NPM / JavaScript library package security …  
+    * On NPM: build … also provides verifiable links back to the …build…   
+      * [https://docs.npmjs.com/generating-provenance-statements](https://docs.npmjs.com/generating-provenance-statements)   
+      * See also [Recent Package Repository Security Capabilities](https://docs.google.com/spreadsheets/d/1JydRQSJ2jTHREmWXXlzlFdhKJ_sY7cORKp_6AI6mRNw/edit?gid=0#gid=0)  
+  * Security Tooling \- Ryan Ware  
+    * [https://github.com/ossf/tac/pull/404](https://github.com/ossf/tac/pull/404)   
+    * We continue to focus on the tools, on SBOM, … Core objectives \- we may need to re-evaluate them.  
+    * SBOM everywhere SIG \- run by Josh and Kate \- very active \- bi-weekly calls. We’re bringing in other OSS projects to find out how they are using SBOMs and get feedback on how we can make SBOMs better. Participated in SBOM-a-rama… BOMctl also announced… SBOM **minimum elements framing document** is in process. **SBOM tooling catalog** has been created.  
+    * SBOMit \- in-toto attestations into SBOMs… Evolving the current specification. Lot of collaboration with protobom… SBOMit’s roadmap is out of date… We’re gonna work on revamping that.  
+    * ProtoBOM \- added support for cyclonedx 1.6.   
+    * BomCtl \- been proactive \- enabled minder for the github org.  
+    * Minder \- Minder is officially a new project in OpenSSF. Legal approval is good. This is an open source platform allowing project owners to manage the security posture of their repos. One of the concerns voiced by the TAC was to work together with Scorecard \- and there is a commitment from the team to work with Scorecard and Allstar.  
+    * Fuzzing collaboration \- ticking along…
+
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10 min* **MAX**  
+  * SOSS community day in Japan is happening… Working on events… Policy day has been rescheduled for **March 4th** in D.C.  
+  * Announcing today more labs \- thanks to the folks who volunteered to help.  
+  * [OpenSSF TAC elections](https://github.com/ossf/tac/blob/main/elections/tac-and-scir-election-process.md#2025-timeline)  
+    * Submissions Received:  
+      * TAC Community Seats (5) submissions  
+      * SCIR (0) submissions. I suggest leaving the SCIR open for a few more days.   
+      * We received 14 voter registrations.  
+    * Concern was raised regarding the lack of submissions to the open positions. TAC members felt like communications weren’t enough and we should extend and do more.   
+    * The question was raised about voter registration and its purpose. It was suggested that post this election cycle we revisit the current process to streamline things.   
+    * Washington to provide an adjusted election timeline to allow more time for self-nominations and voter registrations.   
+  * TI funding deadline for 2025  
+    * Nov 29th  
+* Issues for VOTE (list issue \#)  
+  *    
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *   
+* Updates on older matters \- *15 min* **MAX**  
+  * [Issue \#264](https://github.com/ossf/tac/issues/264) \- Where should pre-sandbox / prototype projects live?  
+  * Marcela \- Several of our sandbox projects have developed prototypes and demos prior to joining OpenSSF. So where should these early collaborations live?  So we could provide a lab space for prospective OpenSSF projects… The idea would be 3-6 months in an OpenSSF labs github organization… Could make collaboration between different companies smoother.  
+  * Ryan: like this idea \- a lot of time this happens ad-hoc in different ways so like this idea.  
+  * Michael: contrarian \- not sure we need this \- what are the challenges today that this addresses? Do we need official governance around this? I think there’s value in this…  for delineating between a project and the official spec (e.g. SLSA)...   
+  * Arnaud: in W3C we created community groups \- one of the key reasons was IP management \- in the case of an open Source thing \- ensuring sign-ups on the repo… If people do it in their own way then the history might not be so clean. One reason would be to advertise more broadly \- it’s in our interest to help that. Setting up the proper framing would be necessary. Hyperledger also used this approach \- hyperledger lab. A few “lab stewards” \- volunteers \- to do a sanity check on the proposal \- requires sign-off by 2 to 3 people. You don’t want to allow spam etc… Also a process to transfer repos… idea is to have a minimal process.  
+  * Dan: \+1 Arnaud \- also we need IP and Antitrust assurance \- helps for big orgs.  
+  * Zach: We need processes and procedures \- TAC could work on that \- and we would need staffing. I hear Michael’s concern. There's a tricky balance \- we will need to do IP review when something goes to the sandbox.  
+  * Marcela: agree with Arnaud & Dan \- I had some experience with one of the LF labs type things \- a simple process . Then the transition to labs would be smoother. All about establishing a common governance structure for some of these projects that should be happening in the open and are probably related to OpenSSF projects.  
+  * Michael: I agree with everything \- the thing I’m concerned with \- making it as lightweight as possible. Also we need: something like “this is what an OpenSSF project looks like” \- if you start doing the right thing \- giving folks a template \- practices to follow from Day 1\.  
+  * Bob: Agree with what MIchael said \- the marketing benefit is good \- I’m in favor of this.  
+  * Zach: We have enough of a consensus…  
+  * Macela: to work on this \- going to take the hyperledger process and use it as a starting space.  
+  * Dan: happy to help  
+  * Arnaud: happy to help \- right now the model is “easy to start, easy to die” \- it takes a bit of work \[in hyperledger\] to “perish” the labs that went no-where. You have to plan for that. It’s still a minor, simple process to archive the repos. Other aspect: from a marketing PoV you cannot call yourself an “OpenSSF initiative” \- they are an “openssf lab”. On paper we have to have a clear discrimination \- so no confusion.  
+* AOB  
+  * None this week  
+  * We’re thinking about doing an async for November due to conflicts.  
+  * Submissions for community seats / SICR…   
+  * Agreement to extend the voter registration… and do some additional outreach…  (Naomi)  
+  * Some discussion on tweaking the voting process to increase engagement (Naomi)
+
+# 
+
+# **2024-10-15**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x  | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x  | Bob Callaway (Google, **Sigstore, A-O**, **TAC**)   | he/him | bobcallaway |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x  | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Co-Lead, TAC**) | he/him | camaleon2016 |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Sarah Evans (Dell Technologies, **GC,** **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC Chair**) | he/him | steiza |
+| x  | David Edelsohn (IBM / **CTI AI Alliance**) | he/him | edelsohn |
+|   | Henri Yandell **(**AWS **/ Alpha-Omega)** | he/him | hyandell |
+| x  | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) | he/him | jeffmendoza |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Angelah Liu (LF) | she/her |  |
+| x | CRob (LF) | he/him | SecurityCrob |
+| x | David A. Wheeler (LF) | he/him | david-a-wheeler |
+| x | Jeff Diecks (LF) | he/him | GeauxJD |
+| x | Naomi Washington (LF) | she/her | Naomi-Wash |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Riaan Kleinhans (LF) | he/him | riaankleinhans |
+| x | Sally Cooper (LF) | she/her |  |
+| x | Todd Moore (LF) | he/him |  |
+| x | Evan Anderson (Stacklok) | he/him | evakanderson |
+| x | Isaac Hepworth (Google) | he/him | hepwori |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Kris Borchers (Independent) | he/him | kborchers |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+| x | Prince Oforh Ashiedu |  |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  David W. & Sarah  
+* Determine TAC quorum  
+  * https://github.com/ossf/tac/issues/369 \- we have quorum\!  
+  * Note that CRob decided to leave TAC chair & TAC since he’s now at LF, but he’s still here as a community member to help.  
+* Update homework/outstanding ARs  
+  *   
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Security Tooling \- Ryan Ware  
+    *  rescheduled to October 29 TAC meeting  
+  * Supply Chain Integrity \- , Isaac Hepworth   
+    * \<link to preso\>  
+    * Report at [https://github.com/ossf/tac/pull/397](https://github.com/ossf/tac/pull/397) see readable version at [https://github.com/ossf/tac/blob/c223c98137158d8218beb039aa479e71cab31de6/TI-reports/2024/2024-Q3-SCI-WG.md](https://github.com/ossf/tac/blob/c223c98137158d8218beb039aa479e71cab31de6/TI-reports/2024/2024-Q3-SCI-WG.md)  
+    * Meeting attendance is notably up, 11-\>15 per meeting, primarily due to new TIs joining the WG. Zarf, Security Insights. Waiting: Trusted Repository Security Initiative (TRSI)  
+    * Looks “ready to graduate” \- need to do the paperwork  
+    * SLSA has completed many of its issues, a few left fot new version  
+    * S2C2F \- working on synchronizing with SLSA.  
+    * ZARF \- goal is version 1.0 by end of year, want to have draft final for SOSS Fusion. We're trying to complete it by kubecon, probably won’t make that (aggressive schedule).  
+    * Want to have machine-readable attestations.  
+    * Jay White: Add as a caveat. SLSA talks a lot about provenance, etc., S2C2F is leaning on that as well.  
+    * Where can we learn more about TRSI? Will provide a link.  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  *  Voting process update (Naomi)  
+    * Notification for the community-elected TAC seats was sent to the TAC mailing list and slack general channel.   
+      * [Community Election Self-Nomination Form](https://forms.gle/kanWZDrpT3dT79gD9) \- 3 Seats Open  
+      * [SCIR Self-Nomination Form](https://forms.gle/2wzS6hgXQoiTxXKn9) \- 1 Seat Open  
+      * [Voter registration](https://forms.gle/2FofZgurk8GzZb7h7)  
+    * There was an issue with the adjustment of the gb-appointed seats timeline. This has been corrected and follows the previous timeline set. PR has been approved, but needs to be merged to update the [.md file](https://github.com/ossf/tac/blob/main/elections/tac-and-scir-election-process.md).   
+    * Election dates: Full timeline is in the [md file](https://github.com/ossf/tac/blob/main/elections/tac-and-scir-election-process.md) ([about to be updated](https://github.com/ossf/tac/pull/396)):  
+      * Community Self-Nomination & Security Community Individual   
+        * October 14: Self-Nomination and Voter registration period starts. Send calls for nominees and eligible voters in email and on Slack.  
+        * October 27: Self-Nomination and Voter registration period ends, 11:59 pm PDT  
+        * October 28 \- November 1: Validation Period of nominee submissions  
+        * November 4: Slate of respective nominees and ballot or link to an electronic voting system sent to registered voters.  
+        * November 17: The voting period ends at 11:59 pm PDT  
+        * November 18: The election winners announced  
+      * GB appointment process timeline:  
+        * November 18 The GB-appointed TAC representative period starts. An email is sent to all GB members informing them of the vote, the results from the community election, and to look for a separate email with the ballot.  
+        * November 23 Send an email reminder to GB members.  
+           December 1 The voting period ends at 11:59 pm PST  
+        * December 2 The GB-appointed TAC representatives announced  
+    * OpenSSF TI Funding Project Board \- [https://github.com/orgs/ossf/projects/25/views/1](https://github.com/orgs/ossf/projects/25/views/1)  
+* Issues for VOTE (list issue \#)  
+  * [TAC PR 390](https://github.com/ossf/tac/pull/390) \- OpenSSF Scorecard Incubating application   
+    * Scorecard is current sandbox, applying for incubation  
+    * There are multiple Scorecard projects, making this a little confusing. Allstar is listed separately. Thinking about longer-term having “Scorecard” consolidated, having multiple repos. Jeff Mendoza \- I thought this was settled, documentation updated, but TAC docs wasn’t updated I guess. So we have Scorecard Monitor, Scorecard Allstar, etc.  
+    * Need to update the website. Sigstore is similar \- it has several repos, but there’s one “Sigstore” line.  
+    * Arnaud: Don’t know about baseline format.  
+    * CRob: I’ll work on baseline for the Scorecard.  
+    * Arnaud: Let’s vote async on GitHub, once we have the baseline info  
+  * [TAC Issue 391](https://github.com/ossf/tac/issues/391) \- \[RFC\] Proposal to extend TAC call from 60 to 90 mins every 2 weeks  
+    * In our 4-year history of meeting, we in the TAC frequently we run out of time. 1 hour/2 weeks isn’t enough time to do our work. Proposal: extend 60 to 90 minutes.  
+    * Healthy discussion on the issue :-). Some wanted to see more work offline.  
+    * CRob: We’ve tried to get more done async, hasn’t helped enough so far. Of course, if we finish early, we should give time back.  
+    * Michael: I worry that work expands to fill the time available.  
+    * Sarah: Is there a sense that the TAC isn’t providing enough? Or is cadence (adequately) meeting community needs?  
+    * CRob: Things like funding and adoption of new projects needs more time  
+    * Arnaud: Not clear how much we’re missing out. Still room for improvement on online/async.  
+  * [TAC Issue 369](https://github.com/ossf/tac/issues/369) (Riaan) Provide Logos to Sandbox Projects  
+    * In the light of over spending on the Creative service budget for 2024\.  
+    * Should we give projects artwork for Sandbox level, or wait for incubating?  
+    * Let them have the “sandbox” badge at Sandbox, and get a full logo once they become incubating. Harry had suggested that it’s better at Sandbox because projects will just do it anyway & considered a negligible expense.  
+    * Sarah: I’d prefer to keep the logo as a carrot \[to become incubating\]\! The sandbox “egg” is fine for sandbox projects.  
+    * Zach: Looks like we have consensus. Sandbox gets general OpenSSF “egg” badge, and each incubating project gets its own logo (funded by OpenSSF). That’s a carrot for becoming an incubating level.  
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * \[CRob+ Riaan\] \- TAC Meeting Agendas as a Issue discussion  
+    * What about note-taking? Google docs? Crob will create an Issue this can all be linked to.  
+      * It’s been really helpful to be able to take notes in real time. There is the problem that historically some people have trouble accessing Google docs (banks, etc.)  
+      * We need to be able to take interactive minutes, where people can see & take part.  
+      * Would love to see an agenda on GitHub, but hard for minutes.  
+      * Perhaps transfer minutes later to GitHub. It’s working.  
+      * You’ll never find a solution for financial folks, they often block other sites like GitHub as well. It might be wise to rotate Google docs into GitHub every once in a while, to deal with the “Google doc eventually gets corrupted” problem, instead of a single long-running Google doc.  
+      * Proposal: GitHub agenda \-\> Google docs for notes \-\> GitHub for final. Riaan will draft up a sample/example.  
+* Updates on older matters   
+  * [TAC input on MVSR update for 2025 · Issue \#380 · ossf/tac (github.com)](https://github.com/ossf/tac/issues/380) Sarah  
+  * Is this ready to close out? Sarah will document what TAC has done in a comment. Other TAC members please document if you've participated, etc. Not a requirement….Sarah will close out today.  
+* AOB  
+  * None this week  
+* We’ll end early. This is the first TAC meeting run by Zach\!   
+  * Zach: Thank you everyone\!
+
+# **2024-10-01**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | Bob Callaway (Google, **Sigstore**, **TAC**)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG & Vuln Disc WG, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Marcela Melara (Intel, **DEI WG Co-lead**, **TAC**) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies, **GC,** **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC**) | he/him | steiza |
+| x | David Edelsohn (IBM / **CTI AI Alliance**) | he/him | edelsohn |
+| x | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) | he/him | jeffmendoza |
+| x | Ryan Ware (**Tooling WG Lead**) | he/him | ware |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Angelah Liu (LF) | she/her |  |
+| x | David A. Wheeler (LF) | he/him | david-a-wheeler |
+| x | Jeff Diecks (LF) | he/him | GeauxJD |
+| x | Naomi Washington (LF) | she/her | Naomi-Wash |
+| x | Ram Iyengar (LF) | he/him | ramiyengar |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Riaan Kleinhans (LF) | he/him | riaankleinhans |
+| x | Sally Cooper (LF) | she/her |  |
+| x | Todd Moore (LF) | he/him |  |
+|  |  |  |  |
+| x | Aeva Black (CISA) | they/them | AevaOnline |
+| x | Madison Oliver (GitHub) | she/her | Taladrane |
+| x | Georg Kunz(Ericsson) | he/him | gkunz |
+| x | Adolfo Gracia Veytia (Stacklok) | he/him | puerco |
+| x | Juan Antonio Osorio (Stacklok) | he/him | JAORMX |
+| x | Evan Anderson (Stacklok) | he/him | evankanderson |
+| x | Luke Hinds (Stacklok) | he/him | lukehinds |
+| x | Stacey Potter (Stacklok) | she/her | staceypotter |
+| x | Ed Thomson (Stacklok) | he/him | ethomson |
+| x | Louis Lang (Phylum, Inc.) | he/him | louislang |
+| x | Kris Borchers (GM Financials) | he/him | kborchers |
+
+1Oct TAC agenda item: (Aeva Black-CISA) DHS S\&T SVIP topic call on intrinsic identifiers and software artifact dependency graphs
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *    
+* Determine TAC quorum  
+  *  6+CRob \- we have a quorum for today\!  
+* Update homework/outstanding ARs  
+  * Welcome the new interim TAC Chair Zach\!  
+    * CRob felt he shouldn’t be TAC chair given new employer & that he was a GB appointment.  
+      * Big thanks to CRob  
+      * Lots to do\! E.g., we have some funding approved but not dispersed, TAC elections.  
+    * 2025 TAC election will be starting soon\!  
+      * 3 member seats \+ 3 GB seats will be up for voting  
+        * The 3 member seats are open to the community   
+    * Update on Q3 TI Funding  
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Securing Critical Projects \- Amir & Jeff  
+    * [TAC PR 389](https://github.com/ossf/tac/pull/389)  
+    * Jeff Mendozza discussed the project progress  
+    * The sub-projects are progressing steadily, but the key initiative of identifying critical projects has stalled due to low meeting attendance over the past few months. Metadata has been roughly scoped, but there is hesitancy about reaching consensus on the details  
+    * Definition of “malicious package” – does this include nuisance ware like reputation farming?  
+    * Questions about funding process for POC  
+    * \[Marcela\] Where do you think the low attendance in your working group is coming from? Do you believe it's part of the general lack of momentum affecting other TIs, or is there something specific happening in your working group?  
+      * Lots of interest in defining the critical projects list, but less interest now that the initial curation has completed.  
+    * \[Marcela\] Malicious Projects – what are the data sources (package analysis, ReversingLabs)?  
+    * \[CRob\] Funding request – have funded contractors before, need to better document the process.  It’s easier to approve clear requests with outcomes.  May need to fund “planning” and then “execution” separately.  
+    * \[Arnaud\] Where is the critical projects list used?  If people don’t see the impact of the list, then it’s harder to motivate.  E.g. Alpha-Omega has its own list.  
+    * \[Sarah\] How often does the critical projects list get reviewed for updates? Historically, it has been updated on a 2-year cycle, but doesn't have an established cadence.  Want to rate-limit the frequency of updates.  Collect feedback from consumers on desired update frequency.  
+  *    
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  *  New OpenSSF Staff  
+    *  Welcoming new team members \- Chief Architect (CRob) and Technical Project Manager (Jeff Diecks) positions filled  
+  * [SOSS Fusion](https://events.linuxfoundation.org/soss-fusion/): October 22-23  
+    * Scorecard Contributor Workshop October 21  
+  * [WG Annual report update](https://docs.google.com/document/d/1co-UtA-hc0HWqk6JSBHdz-Itl4f3CN0Pz2OGhuerVyw/edit#heading=h.9syzlj82gho) due today\! Share your updates & news [here](https://docs.google.com/document/d/1co-UtA-hc0HWqk6JSBHdz-Itl4f3CN0Pz2OGhuerVyw/edit#heading=h.9syzlj82gho)  
+  * [TECH TALK: Jumpstart Your Journey: Mastering OSS Security Development with the Linux Foundation Education](https://openssf.org/resources/tech-talks/openssf-tech-talk-jumpstart-your-journey-mastering-oss-security-development-with-the-linux-foundation-education/) Thursday, October 10 | 1:00PM EDT (Featuring CRob, David Wheeler, Sarah Evans, and Glenn Cate) Register [here](https://openssf.org/resources/tech-talks/openssf-tech-talk-jumpstart-your-journey-mastering-oss-security-development-with-the-linux-foundation-education/)\!  
+* Issues for VOTE (list issue \#)  
+  * [TAC PR 386](https://github.com/ossf/tac/pull/386) \-  Apply to donate Minder to the OpenSSF \- *15 min*  
+    * Evan Anderson \- [Presentation](https://docs.google.com/presentation/d/1em0pdt-h-ghPdkmbklXw8_LvuQzo-gAxZ8NFVPQKkpQ/edit)  
+    * \[Arnaud\] How practical is it to build & run on your own?  Do you need a big data set to support it?  Don’t need a big data set – runs on your own GitHub repos, etc, not looking at other resources.  
+    * \[Marcela\] Do you have further community interest?  
+    * \[Sarah\] We should find a TAC sponsor for this to ensure community alignment. \[Bob is willing to sponsor\]  
+    * \[Jeff\] How related to Scorecard / AllStar?  
+    * \[Arnaund\] Are we missing the security baseline requirements from the template?  
+      * \[CRob\] to follow up with Minder folks on addressing security baseline as part of the application.  
+    * \[Dan\] Have a meeting with scorecard on overlap.  
+      * E.g. [Minder has an “enable scorecard” rule](https://github.com/stacklok/minder-rules-and-profiles/blob/main/rule-types/github/scorecard_enabled.yaml)  
+    * 6 in favor – passes  
+  * [TAC Issue 387](https://github.com/ossf/tac/issues/387) \- \[IP policy and license review\] Vuln-Reach Sandbox Project Entry \- *15 min*  
+    * PR: [https://github.com/ossf/tac/pull/388](https://github.com/ossf/tac/pull/388)   
+    * Louis Lang (Phylum, Inc.)   
+    * Rust *library* which parses code into ASTs to determine whether there is a vulnerable path between your code and this third-party code  
+    * Supports TypeScript & JavaScript  
+    *   
+  *   
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * [TAC Issue 380](https://github.com/ossf/tac/issues/380) \- TAC input on MVSR update for 2025  
+    *   
+  * [TAC PR 381](https://github.com/ossf/tac/pull/381) \- Update tac-member-R\&Rs.md  
+    *    
+  *    
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week  
+      
+    
+
+# **2024-09-17 \- Canceled** 
+
+# **2024-09-03**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him |  lehors |
+| x | Bob Callaway (Google, **Sigstore**, **TAC**)   | he/him |  bobcallaway |
+| x  | CRob (Intel, **BEST WG & Vuln Disc WG, End User WG, TAC**) | he/him |  SecurityCRob |
+| x  | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Co-Lead, TAC**) | he/him |  camaleon2016 |
+| x  | Marcela Melara (Intel, **DEI WG Co-lead**, **TAC**) | she/her |  marcelamelara |
+| x  | Michael Lieberman **(**Kusari**, TAC)** | he/him |  mlieberman85 |
+| x  | Sarah Evans (Dell Technologies, **GC,** **TAC**) | she/her |  sevansdell |
+| x | Zach Steindler (GitHub,**TAC**) | he/him |  steiza |
+| x | David Edelsohn (IBM / **CTI AI Alliance**) | he/him |  edelsohn |
+| x | Mihai Maruseac (Google, **AI/ML WG co-lead**) | he/him |  mihaimaruseac |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Angelah Liu (LF) | she/her |  |
+| x | David A. Wheeler (LF) | he/him | david-a-wheeler |
+| x | Jory Borson (LF) | she/her |  |
+| x | Omkhar Arasaratnam (LF) | he/him |  |
+| x | Ram Iyengar (LF) | he/him |  |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Riaan Kleinhans (LF) | he/him | riaankleinhans |
+| x | Sally Cooper (LF) | she/her |  |
+| x | Todd Moore (LF) | he/him |  |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Madison Oliver (GitHub) | she/her | Taladrane |
+| x | Adolfo Garcia Veytia (Stacklok, Protobom/OpenVEX Colead) | he/him | puerco |
+| x | Sergio Rojas |  |  |
+| x | Prince Oforh Ashiedu |  |  |
+| x | Long |  |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  * David,  Reden   
+* Determine TAC quorum  
+  *  We have quorum\!  
+* Update homework/outstanding ARs  
+  * [https://github.com/ossf/tac/issues/235](https://github.com/ossf/tac/issues/235) \- Clarify Community Voter Eligibility documentation and requirements and submit suggestions to the Governance Committee  
+    * TAC \- please add any other feedback.  
+    * [https://github.com/ossf/tac/issues/237](https://github.com/ossf/tac/issues/237) \- Make TAC voting process simpler and clearer  
+      * That will be closed. It should have been closed based on other changes.  
+      * Zach \- It is pending because there was a need to clarify the voting process in the pull request. The pull request was approved and merged a while ago  
+          
+    * Who on staff will work on voting?  
+      * We’ll discuss later, based on other announcements  
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * AI / ML WG,- Mihai Maruseac and Jay White,   
+    * \<l[ink to preso](https://github.com/ossf/tac/pull/377)\> Mihai discussed.  
+    * [https://github.com/ossf/tac/pull/375](https://github.com/ossf/tac/pull/375)   
+    * Model signing \- thinking more about supply chain issues in AI/ML.  
+    * Trying to integrate into other groups, e.g., SPDX AI  
+    * OpenSSF life cycle documents for this group needs to be updated, Mihai will work on.  
+    * Jay White: OASIS steering committee already established, for supply chain for AI/ML. May involve a potential partnership. I’m serving there.  
+    * Also \- looking at S2C2F, esp. ingest model.  
+    * OpenSSF has a unique role to look at DevSecOps, supply chain, etc., and how it could apply to AI/ML.  
+    * There is a focus on creating partnerships with other organizations involved in AI and ML security to connect the work being done across the ecosystem.  
+    * Issues have arisen around the S2 C2 web's model and its applicability to the ingestion and adjustment of large language models and data, leading to discussions with the AI/ML security working group.  
+  *   SOSS Updates   
+    * DC SOSS Summit has been postponed until 2025\.  We will provide updates on these efforts at a future TAC call  
+    *   
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * GM update . Today is Omkhar’s last day as GM. Todd Moore is taking over the role temporarily. We’re looking for a new GM. Adrianne is the new Chief of Staff  
+  * OSS EU (16-18 Sept)  
+    * Booth support \+ Project demos  
+    * In-person TAC meeting 17 Sept  
+  * Next Steps \- OpensSSF & Standardization \- Presented by Jory Burson \-  [Link to Presentation](https://docs.google.com/presentation/d/15UDIo_lkf-KO0bU-pA5gAne0IOwy6e96KK057a3HWpg/edit#slide=id.p)  
+    * Joint Development foundation is a PAS Submiter  
+    * Goal: get DIS numbers in time to submit the ISO versions of OpenSSF specification to CENELEC for CARA Conformity Assessment (Q2 2026\)  
+    * The JTC1 PAS process allows acceptance of standard solutions for IT problems developed outside JTC1, aiming for swift, quality standards for software and digital transformation.  
+    * JDF projects can use the PAS Submission Process to prepare and submit their specifications for consideration and balloting at JTC1.  
+    * Resources are available to guide projects through ISO submission and formal IT specification writing, and the JDF has a successful track record with various standards.  
+        
+  * SOSS Community Day 19 Sept  
+  * We’re working on the 2024 Annual Report\! WG leads \- please share your 2024 updates [here](https://docs.google.com/document/d/1co-UtA-hc0HWqk6JSBHdz-Itl4f3CN0Pz2OGhuerVyw/edit?usp=sharing) by Oct 1, 2024  
+  * Please keep letting people know about LFD121, “Developing Secure Software”\! [https://training.linuxfoundation.org/training/developing-secure-software-lfd121/](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) . We will distribute flyers in Europe (help us if you’re there\!)  
+      
+* Issues for VOTE (list issue \#)  
+  *  TAC Homework \- We have 2 items up for Q3 Funding review:  https://github.com/ossf/tac/issues/352  & https://github.com/ossf/tac/issues/360  Can we please review those and plan to vote on them at our next meeting  
+  * Please flag any issues for voting for next meeting  
+      
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *   [https://github.com/ossf/tac/issues/305](https://github.com/ossf/tac/issues/305) \- We need a process flow for specs to become standards \- Jory  
+  * Long discussion about creating formal standards via the publicly available specification (PAS) process and JDF. Jory can help. However, we must carefully identify what will go through.  
+  * We’ll need to identify the TIs to go through, & see what interest there is. It’d be great to influence the CRA, for example, and they will want to reference formal standards.  
+      
+* Updates on older matters   
+  * Friday is the last day for funding submissions. See TAC Slack channel, we have 2 proposals. TAC members, please comment\!  
+* AOB  
+  * None this week
+
+# **2024-08-20**
+
+6Aug call rescheduled to the 20th due to the number of speakers and TAC members that will not be present.
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x  | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | Bob Callaway (Google, **Sigstore**, **TAC**)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG & Vuln Disc WG, End User WG, TAC**) | he/him | SecurityCRob |
+| x  | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Co-Lead, TAC**) | he/him | camaleon2016 |
+| x  | Marcela Melara (Intel, **DEI WG Co-lead**, **TAC**) | she/her | marcelamelara |
+| x  | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x  | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC**) | she/her | sevansdell |
+| x  | David Edelsohn (IBM / **CTI AI Alliance**) | he/him | edelsohn |
+| x  | Mihai Maruseac (Google, **AI/ML WG co-lead**) | he/him | mihaimaruseac |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Naomi Washington (LF) | she/her | Naomi-Wash |
+| x | Angelah Liu (LF) | she/her |  |
+| x | Riaan Kleinhans (LF) | he/him | riaankleinhans |
+| x | David A. Wheeler (LF) | he/him | david-a-wheeler |
+| x | Omkhar Arasaratnam (LF) | he/him |  |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Aeva Black (CISA) | they/them | AevaOnline |
+| x | Madison Oliver (GitHub) | she/her | Taladrane |
+| x | Georg Kunz (Ericsson) | he/him | gkunz |
+| x | Jacques Chester (independent) | he/him | jchester |
+| x | Fred Gan (Huawei) | he/him | fredgan |
+| x | Eddie Knight (Sonatype, Inc.) | he/him | eddie-knight |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Sarah Evans  
+* Determine TAC quorum  
+  *  We have quorum\!  
+* Update homework/outstanding ARs  
+  *    
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Best Practices \- CRob   
+    * [BEST WG Update PR](https://github.com/ossf/tac/pull/359) (see that for details)  
+    * Sarah: Recommend a BEST co-lead  
+    * Sarah: Thanks to Ericsson for their contributions to the C++ compiler hardening guide  
+    * Sarah: Thanks to OpenJS for contributing feedback to the Security Baseline SIG  
+  *  End Users \- Jonathan & Jacques  
+    * Jacques: Unhealthy state, not much participation. People have had to devote time to other things. Perhaps the archival process? The need persists, would like to make it easier to resurrect it later.  
+    * Arnaud: It’s easy to archive & un-archive, process-wise. Best to admit it.  
+    * Jay: When the end-users group was spinning up, I was wondering if it should just be a SIG of another WG. There may not be enough meat on the bone for a WG, but might be enough for a SIG. Maybe part of supply chain integrity WG?  
+    * Georg: Agrees with archiving, but wonders if it sends a bad “taste” signal to future end users enterprises.  
+    * Sarah: Thanks Jacque/Jonathan for leadership and contributions. Agree with archiving, and believe this is a natural progression for the open source community. End users may be going directly to the SIGs/WGs vs an End User WG. It has certainly served a point in time. Would like to see threat modeling work pulled forward in another WG/SIG when/where it makes sense.  
+    * Arnaud: Agrees with archiving, and in response to Jay’s comment, shouldn’t matter what group is called or where it lives if there is a community to participate.  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * David: PLEASE help us get more software developers enrolled in LFD121.  
+    * Everyone in your organization & project should know how to develop secure software  
+    * As of just now (Aug 20\) we have 878 enrollments in August, biggest \# of enrollments in a month this year. Have 4219 this year. But we’re trying to get 8000 enrollments this year, still short of that.  
+    * Please help\!  
+  * Omkhar: There have been staffing changes, that’ll cause us to delay/postpone some things. Job postings will go up soon.  
+  * Security baseline adoption update \- Eddie/CRob  
+    * if CRob covers this during the BEST WG update, we can skip this (Was covered)   
+* Issues for VOTE (list issue \#)  
+  *  [TAC PR 367](https://github.com/ossf/tac/pull/367) – bomctl sandbox application \- SEEKING TAC APPROVAL  
+    * Has cleared legal review  
+    * 6 TAC members have approved, so it’s already approved\!  
+    * Welcome, officially\!\! Thank you\!\!  
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *  [TAC Issue 255](https://github.com/ossf/tac/issues/255) \- Migrate from branch protection to rulesets?  
+    * Marcela, Mike and Crob will work this asynchronous  
+    * David: tools may need updated to reflect rulesets and branch protection. Currently, scorecard only recognizes branch protection, as an example  
+    * Mike: Sometimes, rulesets applied at the company level aren’t easily visible on projects via API. He’s dealing with this at his own company.  
+  *  [TAC Issue 369](https://github.com/ossf/tac/issues/369) \- Logos for Sandbox Projects  
+    * Arnaud: if it is free, that is good. Also, need a “carrot” for sandboxes to move to incubation  
+    * Omkhar: There is a flat fee for graphic design, and the graphics company hasn’t pushed back on dressing too many goose logos.  
+    * Sarah: Would prefer to use the “nest egg” sandbox logo and use a carrot to get the group to incubate. If data comes in that shows that logos help sandbox groups move to incubated, then can perhaps adjust. But I recommend leave for now.  
+    * Arnaud: CLARIFICATION. The nest egg image is a BADGE, not a logo.  
+    * David: I’d suggest that projects at sandbox get a logo, as long as there’s some other carrot for moving up, but that’s up to the TAC.  
+    * Arnaud: Let’s keep sandbox projects to the sandbox BADGE for now, and if there is a compelling reason in the future, change to adding a logo  
+    * Naomi/Adrianne: bomctl and protobom have logos. Will follow up with leads to see if that’s helping them move to incubation.  
+    * Crob: let’s put additional comments in the PR.  
+  * [TAC PR 373](https://github.com/ossf/tac/pull/373) – Clarification on logos  
+    *  Was merged \- no discussion   
+  * [TAC Issue 352 \-](https://github.com/ossf/tac/issues/352) Proposal: Expanding Security Benchmarks for Critical OSS in OpenSSF \- Fred Gan \- Senior Software Engineer from Huawei  
+    * Fred presented slides on Misconfiguration in OSS  
+    * What we will do:  
+      * Identify critical OSS  
+      * Collect security configuration rules   
+      * Publish security configuration baselines   
+          
+    * Benefits: 
+
+      
+
+      * Improves security of critical OSS and downstream OSS  
+      * Enhanced security for consumers and enterprises   
+      * Empowered OSS ecosystem
+
+      
+
+    * Sarah: Recommend talking to Alpha/Omega; if this isn’t a good fit with AO, let’s understand why not, then let’s figure out as a next step where to recommend this in OpenSSF WG/SIG.  
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# **2024-08-06 \- Canceled**
+
+# **2024-07-23**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Co-Lead, TAC**) | he/him | camaleon2016 |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC, DEI WG Co-Lead**) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC**) | he/him | steiza |
+| x | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) | he/him | jeffmendoza |
+| x | Michael Scovetta (Microsoft, **Alpha-Omega, Metrics & Metadata WG co-lead**) | he/him | scovetta |
+| x | David Edelsohn (IBM / **CTI / AI Alliance**) | he/him | edelsohn |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Angelah Liu (LF) | she/her |  |
+| x | Bennett Pursell (LF) | he/him |  |
+| x | Dana Wang (LF) | she/her |  |
+| x | David A. Wheeler (LF) | he/him |  |
+| x | Harry Toor (LF) | he/him |  |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Aeva Black (CISA) | they/them | AevaOnline |
+| x | Madison Oliver (GitHub) | she/her | Taladrane |
+| x | Carlos O’Donell (Red Hat / CTI) | he/him | codonell |
+| x | Paul Eggert (UCLA) | he/him | eggert |
+| x | Yesenia Yser (**DEI WG Co-Lead**) | she/her | Cyber-JiuJiteira |
+| x | Chris de Almeida (IBM) | he/him | ctcpip |
+| x | Long |  |  |
+|  |  |  |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Dan A \+ Madison O \+ David E  
+* Determine TAC quorum  
+  *  8 TAC members, we have quorum  
+* Update homework/outstanding ARs  
+  * [https://github.com/ossf/tac/pull/351](https://github.com/ossf/tac/pull/351)  
+    * [https://github.com/ossf/tac/pull/353](https://github.com/ossf/tac/pull/353)  
+    * [https://github.com/ossf/tac/pull/354](https://github.com/ossf/tac/pull/354)  
+    *   
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * CTI \- David Edelsohn & Carlos O’Donnell  
+    * [July 23 2024 CTI - TAC Update](https://docs.google.com/presentation/d/1q29BsHwrL_yGE455R_pj_rrlmSBvawn_ZQLe4SS2Zxc/edit#slide=id.p1)  
+    * \*Carlos presents slides\*  
+    * “No open questions for TAC currently.”  
+    * Paul Eggert: some people on \[[libc-alpha](https://inbox.sourceware.org/libc-alpha/20240708224601.GC29242@gnu.wildebeest.org/T/#mc47632ab1e75ee0c10f6675bcf1708e810c6212e)\] mailing list have expressed concerns about transition… there is concern on part of the community about the transition. Some remarks talked about communication issues \- it seems like for significant elements of the community there hasn’t been enough communication. We don’t want this to appear as a hostile take-over. Process has been opaque and motivations haven’t been expressed to the community. Want to urge people to not steamroll \- but do this more gradually. Might be more expensive, but in the long run will be worth it.   
+    * Crob: good feedback, thank you.  
+    * Carlos: I’ve taken not \- we need to do a monthly or quarterly update to certain communities. Sometimes you need to feed back more consistently. The preconditions for consensus have to be \[aligned\] goals and some in the community have different goals. We can continue to update the faq and slow the roll-out. Let’s have a brainstorm session on improving the roll-out.  
+    * Paul Eggert: I think something like that would be helpful. There is a trust issue. Communication will help.  
+    * \*agreement to coordinate\*  
+    * Sarah: like this dialog. A one-pager MVSR that could be shared with members of the community would be good. A big part of security is availability. We need to articulate this \- digital public good.  
+  *  DEI \- Jay White, Marcela, Yesi  
+    * [\<link to preso\>](https://github.com/ossf/tac/pull/357)  
+    * Marcela: \*presents update\* \- [pr 357 on the TAC repo](https://github.com/ossf/tac/pull/357)   
+    * …been making good progress. Some of our recent activities: appointing wg co-chairs to support Jay: Yesenia and Marcela.   
+    * …held a DEI panel discussion at SOSS community day \+ blog post. We saw new attendees because of this.  
+    * …community office horse \- first ones are this Thursday. We’ll host different speakers who can address the community.   
+    * Yesenia: will [re-share post](https://www.linkedin.com/posts/yser_opensource-cybersecurity-community-activity-7221484123461169154-qlka?utm_source=share&utm_medium=member_desktop). We’re looking to do **tips of the month** on how to “get into cyber”. If you’re interested, let us know.  
+    * Marcela: want to start reaching out to other LF communities… Lack of momentum is a challenge. 2 main asks: please amplify the work by reposting to networks. Also refer colleagues to the working group.  
+    * Daniel will share through Fediverse  
+  *    
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * David W: Course\! Course\! Course\!  
+    * [“Developing Secure Software” (LFD121) course](https://training.linuxfoundation.org/training/developing-secure-software-lfd121)   
+    * Sarah: how can we get that course to our under-served participants …  
+    * David: free course \- so… please share.  
+    * Chris: I think it delivers a badge on completion.  
+  * Events (Harry):  
+    * SOSS community day EU [agenda has gone out](https://events.linuxfoundation.org/soss-community-day-europe/program/schedule/).  
+    * [SOSS fusion](https://events.linuxfoundation.org/soss-fusion/)… agenda will go live in early august timeframe. 200 submissions…   
+  * Harry: Slowness of funding on technical initiative \- we are working on the process. Some of these things are for technical things \- we’re working on it. If anyone has issues please reach out to myself, Omkhar, [operations@openssf.org](mailto:operations@openssf.org).   
+    * Michael L: right now there’s a gap for when something approved by TAC to when it gets actioned. Something for us to talk through. Does it become a JIRA ticket or a separate github issue… how are we tracking?  
+    * Harry: we’ve been [tracking it in github](https://github.com/orgs/ossf/projects/25) \- but it appears “stuck in gm approval” but not accurate \- so the minutiae updates are not captured.  
+  * Dana: First of all thanks for the support from TAC members. Updates:  
+    * Security baseline \- checked into TAC repo \- got 6 out of 7 votes.  
+    * Have automated the code for project onboarding to github \- waiting for approval from David W. and Bennet.  
+    * Architecture framework \- in its early stage. Have had feedback from Sarah and Crob. Will provide an easier way to understand technologies in our space and choose technologies quickly. Touches on the concerns Marcela brought up \- will lower the barrier to entry.  
+* Issues for VOTE (list issue \#)  
+  *    
+    *   
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * [TAC Issue 352 \-](https://github.com/ossf/tac/issues/352) Proposal: Expanding Security Benchmarks for Critical OSS in OpenSSF \- Fred G \- *15 min*  
+    * Rescheduled to XXAug  
+  * [TAC Issue 360](https://github.com/ossf/tac/issues/360) \- Proposal: Funding Critical Projects POC with commercial vendors \- David E \- *15 min*  
+    *  \*presents slides\*  
+    * David E.: suggesting OpenSSF to coordinate vendors in the cybersecurity space… as a complement to other methods. Currently a lot of work in securing critical projects WG …   
+    * … need for an additional …   
+    * E.g. a startup called cyberframe …   
+    * E.g. utilize tidelift … has an opportunity to engage with open source projects in their business…  
+    * Complement what OpenSSF is doing… leverage commercial solutions out there. Where there are communities … more amenable / less amenable. Improve the cybersecurity environment… Actively address all the tools available.  
+    * Risks are identifying incorrect projects / funds used ineffectively… hopefully this could be analyzed by improvements of scorecard ratings, improved criteria of criticality and severity.  
+    * Proposal is for an initial poc…   
+    * Michael: I like the idea of sponsoring the community to sustain itself \- is it about security or sustainability. When you get to individual projects it’s hard… Do we need to optimize cost over everything else? What we’ve learned is : if it looks and smells like an important project then it’s important.  
+    * Dan: I’m concerned about vendor neutrality. Is there a way this could be used to leverage vendors to do more things in the clear…   
+    * David E.: this would be using a vendor to disperse grants…  
+    * David E: I understand concerns about favoritism … also OpenSSF is utilizing github, google, drive, etc… various technologies… impossible to be able to avoid vendors… The proposal is to utilize vendors \- to have another analysys \- another way to discover critical projects… Always some sort of point of view… so \- another way to match with the funders … this type of analysis. This would also help TAC and exec leadership…   
+    * Michael L: I like the idea if it’s an open RFP. OSTIF has a good example. Should be aligned with security best practices.  
+    * Harry: I’m a bit lost on what the proposal is \- don’t have a complete end-to-end. What I’d suggest \- one of the working groups we have could put together a simple list \- highlighting the funding sources that are available. Lots of places for funding…  
+    * David E.: open ssf would orchestrate. Use its own funding or alpha-omega… then use that funding to go to a company \- and based on some criteria \- if you think some project is important \- then please do this economic analysis \- what are the projects that are most severe… that are impacted\[?\]. Then go to tidelift … with funding from places \- “here are the projects we’ve determined with cyberframe. Please work with the maintainers with this money to address the issues.” So can we find vendors to do these tasks. To complement.  
+    * Dan A.: I have concerns. Worried about vendor neutrality. And worried about openness.. Not sure vendors would be interested in working with us in this way.  
+    * Jeff: we need a contract that would address the concerns with transparency…  So is the proposal that the TAC would do this or that a working group would do this? Personally I think it should come from a working group.  
+    * David E.: would utilize the security critical projects group as a home. Would need to be lightweight. Would require staff – e.g. to write contracts, handle detail… How can we utilize the market approach?  
+    * Crob: thanks \- let’s continue the discussion in the repo and continue to refine the proposal.  
+  *   
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# **2024-07-09**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) | he/him | camaleon2016 |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC**) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC**) | he/him | steiza |
+| x | Michael Scovetta (Microsoft, **Alpha-Omega, Metrics & Metadata WG co-lead**) | he/him | scovetta |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Angelah Liu (LF) |  |  |
+| x | Dana Wang (LF) |  |  |
+| x | David A. Wheeler (LF) |  |  |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Madison Oliver (GitHub) | she/her | Taladrane |
+| x | Seth Larson | he/him | sethmlarson |
+| x | Henri Yandell (AWS / **Alpha-Omega**) | he/him |  |
+| x | David Edelsohn (IBM / **CTI**) | he/him | edelsohn |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  * Dan A.  
+  * David A. Wheeler will help\!  
+* Determine TAC quorum  
+  *  ✅Have quorum (all but Bob)  
+* Update homework/outstanding ARs  
+  *    
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Alpha-Omega \- ~~the Micheals~~ Henri  
+    * [TAC PR 349](https://github.com/ossf/tac/pull/349)  
+    * [June Report](https://alpha-omega.dev/wp-content/uploads/sites/22/2024/07/June-Monthly-2024-Report.pdf) just published  
+      * Debian/Ubuntu LLVM Packaging update  
+      * ISRG AV1 Rust port  
+      * OpenRefactor metric update  
+      * Ruby Central update  
+    * Notes (Alpha-Omega):  
+      * looking at packages important in AI… looking for TAC’s attention ;  
+      * continuing to work on “open refractor-y” things…  
+      * Working with Apache. Just like eclipse they are working on end-to-end tooling, proving that all is tested. Apache doesn’t pay for development of open source \- focusing on volunteer effort.  
+      * On Homebrew core, they have end-to-end attestation.  
+      * I feel like we have many lego bricks, but the end-to-end story isn’t clear. How can this be seamless and easy as a user? I do like that it’s starting to become real.  
+      * OpenSSL, Eclipse have both reported on security reviews \- no issues found.  
+      * Update from ISRG on LibAV1 \- port over to Rust. The moving of things from C/C++ to Rust  is happening .. but people need to maintain that code \- so in this case we have the Chromium team signed up to it after it’s ported by ISRG.  
+      * Ruby Central Update. Double funding … old AWS funding into Ruby gems \+ Alpha-Omega funding. Same story as Homebrew.   
+      * Questions:  
+        * Michael: would like to see more of the feedback… what challenges did projects have e.g. in adopting SLSA? If Homebrew is building out a verify tool could that code come back into OpenSSF, eg?  
+        * Henri: Noted that there will be a Roundtable at Open Source Summit Europe (Vienna) \- so getting people in the same room could help that.  
+        * Zach: read $4m of $5m deployed \- great\! \- we are also ramping up our fund for security improvements… So what sorts of things should we be working on, etc…?  
+        * Henri: We are also talking to STF and … others.   
+      * David A. Wheeler: Quick note: Ruby Central has just been approved as an OpenSSF associate member, this is very new so it’s not publicly listed yet. This will make it easier to do even more collaboration ​​[https://github.com/ossf/Governance-Committee/issues/31](https://github.com/ossf/Governance-Committee/issues/31)   
+    *   
+  *   Sigstore \- Luke  
+    * \<link to preso\>  
+    * Zach: I can give a 3 minute update. The headline is that there is a SigstoreCon coming up co-located with Kubecon \- November; A lot of the work happening in sigstore area is happening in the client libraries \- python, js, go, ruby, etc… Rust is not happening yet. Progress has been great. A lot of ecosystems are making use of sigstore.. Including npm, homebrew, and some commercial applications… Also folks are adopting sigstore, large individual projects, but the focus of the project as a whole is on client libraries…  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  *  David A. Wheeler  
+    * Secure Software Development Education 2024 Survey has been released\! [https://openssf.org/blog/2024/07/05/why-are-organizations-struggling-to-implement-secure-software-development/](https://openssf.org/blog/2024/07/05/why-are-organizations-struggling-to-implement-secure-software-development/)  
+      * ​​Lots of stats, e.g., Software developers with less than one year of experience report the highest lack of familiarity with developing secure software (75%)  
+      * Biggest need: more on security architectures (working on such a course)  
+    * We’re trying to increase enrollment in Developing Secure Software (LFD121) course (“fundamentals”). Have posted posts encouraging this, e.g.: ​​[https://openssf.org/blog/2024/07/08/learn-how-to-develop-secure-software/](https://openssf.org/blog/2024/07/08/learn-how-to-develop-secure-software/)  
+      * if you can encourage your organizations to get developers to take course, please do\!  
+      * If you have ideas on how to increase enrollment, please let David know\!  
+      * Dan A: I encouraged my company’s dept.training department to do this and I encourage others to do the same. Key words: “free training”.  
+* Issues for VOTE (list issue \#)  
+  *    
+    *   
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * [TAC Issue 331](https://github.com/ossf/tac/issues/331) \- TI Lifecycle \- How do we want to handle TIs that are going dormant and/or having challenges in finding new leaders \- *15 min*  
+    * Michael: we’re looking to archive the “toolbelt” \- we don’t want the   
+    * Arnaud: the gist of it is right.  
+    * ACTION: CROB to create a PR with the suggested new re-homing process. Can comment and make adjustments…  
+    * Michael: We should keep track of how often we are archiving projects… there has been lower participation due to budget cuts… we should track that and see if we can unarchive if we get more participation…  
+    * Arnaud: we can rely on quarterly reports… hard for us to keep an eye on everything…  
+  * [TAC Issue 333](https://github.com/ossf/tac/issues/333) \- Secret Scanning  
+    * Dana: issue I raised to enable secret scanning and protection at the enterprise level… if a repo doesn’t need it they can disable… so far I got 8/9 votes from TAC members. Can we close this?  
+    * Dana: I will work on the implementation after we get confirmed today.  
+  * Meta: Zach: TAC did this thing out of our in-person meeting \- documenting our decision making process. We have the decision process document \- to ensure people know that they don’t need unanimous TAC consensus… To enable async.  
+    * [https://github.com/ossf/tac/blob/main/process/TAC-Decision-Process.md](https://github.com/ossf/tac/blob/main/process/TAC-Decision-Process.md)   
+  * [TAC PR 348](https://github.com/ossf/tac/pull/348) \- Added clarity for projects & sig documentation \- *5min*  
+    * MERGED  
+  * Security baseline work [OpenSSF Security MVP · Issue \#215 · ossf/tac (github.com)](https://github.com/ossf/tac/issues/215) \- Dana  
+    * MVP \- baseline document is complete \- I also had a couple of review session already \- booked a review session with TAC members \- getting support form TAC \- have support from Arnaud, Dan and … \- would like to bring Baseline for adoption in OpenSSF and have 3 pilot projects using it … drive it within our own foundation \- and get LF to adopt our baseline at the LF level.  So we talked about a SIG \- bringing other foundations into this initiative \- like CNCF, hyperledger, lf-energy… Because this SIG is going to have people from other foundations.. I’m wondering if TAC could be the governing body, instead of an individual WG  
+    * Dan A: I think this is a great initiative, I think there are a number of things left to do. Doing this as a transparent process seems like the right approach. A SIG is the right approach. Making it a TAC SIG, instead of a WG SIG, might be the right approach. It seems to make sense to me.  
+    * Zach: thanks to Dana for driving this… my understanding was that we would take the requirements and put them as PRs into the TI lifecycles.  
+    * Dana: yes.  
+    * Zach: My suggestion is to take one step of the process \- make the pull request to … for sandbox …   
+    * Dana: I did build a plan in issue215 \- start with Sandbox and get PR approved…   
+    * Zach: in terms of doing this across LF \- hadn’t heard it \- want to think it over \- and need to review the execution [spreadsheet](https://docs.google.com/spreadsheets/d/16YYsJDu1Xw_G3hUVnMiQ9sdvbWoBBt_pHLiVFsYNHVg/edit?gid=1003775317#gid=1003775317). But does that belong in “LF proper”? Or in a foundation?  
+    * Crob: Regardless of what form it takes and where it sits \- do we have members of the community and a leader ?   
+    * Dana: Eddie Knight has volunteered as chair, we are looking for a co-chair. I know we have to have 3 people. The key aspect is the governing body \- is it TAC or working group? If we want to establish it as a LF baseline .. I feel it encompasses all the things in OpenSSF i feel TAC would be …  
+    * Do you have a TAC POC? Need one. CRob \- I have no more room. Dan A \- I’m willing to sponsor, but can’t commit to co-chairing.  
+    * Arnaud: two docs need to be linked… a pull request that has the security baseline to the process directory and then add links to the various stages… so we have those two in parallel. In terms of the adoption plan \- when we get to implement it, we still need to define some transition path so we can get all the existing TIs to get to it.  
+    * \*discussion of how we relate this to the lifecycle document\*  
+    * Create a pull request, then we (TAC) can vote.  
+    *  ACTION: Dana to work on a pull request.  
+    * Marcela: \+1 to adding a link to the baseline doc in the lifecycle doc  
+    * Jay: in reference to where this would fit \- i think it might fit under the vuln disclosure wg… This sits in that middle layer…  
+    * Michael: We tend to prefer that SIGs and projects be elsewhere \- because the TAC has lots of stuff going on \- but because this cross-cuts all openSSF projects \- we’d still need to have lots of TAC members involved. I do think that it would have to report to the TAC anyway with updates. I hope to see the feedback loop be quick and tight. Inevitably we’re going to run into a roadblock \- a project that “can’t” do one of the things \- so what do we do? Maybe there’s flexibility. We can also take those learnings… so that when it ends up in the hands of LF more broadly it will make more sense.  
+    * David: I commented that this SIG might be a good fit in the best practices WG. The TAC must decide where it goes. However Michael makes a good point which is that this particular thing is going to require more interaction with the TAC, no matter where it sits. That’s a good thing.  
+    * Sarah: Bit of a counterpoint \- sometimes you need to go back to the drawing board \- maybe we need a working group where we can make cross-cutting recommendations \- e.g. security toolbelt was cross-cutting. And is being archived… where there is interest, maybe we need a kind of working group that champions cross-cutting efforts like this.  
+    * Crob: Our WG and SIG structure isn’t a hierarchy necessarily… just because you're a SIG under a working group it doesn’t mean you can’t work across foundations… It’s primarily a reporting mechanism. My reservation to adding a SIG under the TAC is that this call has a broader focus … I’d hate to see this call devoured by talking through one particular thing. Whatever it is, we need to invest TAC time on it.  
+    * Marcela: I don’t have a strict problem with the SIG reporting to the TAC … narrowly defined… \*and\* I would like to know what TAC involvement actually involves. Not exactly clear to me besides … discussing helpful options. All TAC members are busy people. So knowing ahead of time what this additional responsibility would require… the SIG should still be a broader community effort.  
+    * Michael: the TAC needs to be involved… but we are the Technical Advisory Council \- so we are the ones saying “yes this a good idea to have these practices.”  
+    * Arnaud: how do we get the community to join in \- there is one way \- essentially “all the TIs should be away that we are aware of working on this as a policy that they will have to live by \- and therefore they will have a stake in it \- so they should help us”.   
+* Updates on older matters   
+  *   
+* AOB  
+  * 
+
+# **2024-06-25 \- Canceled** 
+
+# **2024-06-11**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | Bob Callaway (Google, **TAC**)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC**) | she/her | marcelamelara |
+| x | Zach Steindler (GitHub,**TAC**) | he/him | steiza |
+| x | Ryan Ware (Intel, **Tooling WG Lead**) | he/him | ware |
+| x | Seth Larson | he/him | sethmlarson |
+| x | Neal McBurnett | He/him | Independent |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Amanda Martin (LF) | she/her | hythloda |
+| x | Angelah Liu (LF) |  |  |
+| x | Bennett Pursell (LF) |  |  |
+| x | Dana Wang (LF) |  |  |
+| x | David A. Wheeler (LF) |  |  |
+| x | Harry Toor (LF) |  |  |
+| x | Omkhar Arasaratnam (LF) |  |  |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Aeva Black (CISA) | they/them | AevaOnline |
+| x | Kenny Paul (LF) | he/him | KennyPaul |
+| x | Fotis Georgatos (CERN) |  |  |
+| x | Cyber Educators |  |  |
+| x | Georg Kunz(Ericsson) | he/him |  |
+| x | Michael Scovetta (Microsoft, **Alpha-Omega, Metrics & Metadata WG co-lead**) | he/him | scovetta |
+| x | Madison Oliver (GitHub) | she/her | Taladrane |
+|  |  |  |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Dan A.  
+* Determine TAC quorum  
+  *    
+* Update homework/outstanding ARs  
+  *  [TAC Issue 333](https://github.com/ossf/tac/issues/333) – GH Secret Scanning & Push Protection \<- TAC Vote requested
+
+    * [TAC Issue 340](https://github.com/ossf/tac/issues/340) – Project Onboarding Action Items
+
+    * [TAC PR 341](https://github.com/ossf/tac/pull/341) \- Zarf adoption as Sandbox project w/in SCI WG \<- TAC Vote required
+
+    *   
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Security Tooling \- Ryan   
+    * \<l[ink to preso](https://docs.google.com/presentation/d/1ubLI-Y9v8gO-MS7rlVdR55RXi27A27Es8LxEXomvfPc/edit#slide=id.p12)\>  
+    * New SBOM Harmonization meeting going on to coordinate SBOM activiti**es**  
+    * **SBOM everywhere** SIG starting “SBOM Everywhere” project \- cataloging tooling out there and how to use it. Will be working on an “SBOM Strike Team” proposal.  
+    * Protobom \- storage interface to allow other tools to be able to interact with protobom \- representation of a SBOM that can interchange between SPDX & Cyclone DX…   
+      * The storage interface facilitates access to bomctl… “A local caching mechanism for protobom” …  
+    * Bomctl \- preparing sandbox application \- they want to diversify the maintainers (currently all in one organization) \- they are looking for *active maintainers* (not just names)  
+    * SBOMit \- spec defining how SBOMs include in-too attestations… Has been going slowly.   
+  * Vulnerability Disclosures- CRob & Madison  
+    * \<[link to preso](https://docs.google.com/presentation/d/1hW_Zp46xBoCRsOUtNM8EUwTQpnDU9MssoE0JEqvkkZg/edit#slide=id.p1)\>  
+    * Published a tabletop framework to help companies and orgs run a cybersecurity mock incident… uploaded all the SOSS community day materials: [https://github.com/ossf/wg-vulnerability-disclosures/tree/main/docs/TTX/SOSS%20Community%20Day%20NA%202024](https://github.com/ossf/wg-vulnerability-disclosures/tree/main/docs/TTX/SOSS%20Community%20Day%20NA%202024)   
+    * Protecting projects from xz-style attacks \- tools for maintainers.  
+    * For OpenVEX, looking for outreach support from the TAC.  
+    * SIREN \- [https://lists.openssf-vuln.org/g/siren](https://lists.openssf-vuln.org/g/siren) ← subscribe here  
+  * Securing SW Repos \- Zach  
+    * [June 11, 2024 Securing SW Repos WG - TAC Update](https://docs.google.com/presentation/d/1PWxTw8yiSnLlClMK0K83hff5XHnkKDkw0OYM0ldWKsk/edit?usp=sharing)\<[link to preso](https://docs.google.com/presentation/d/1PWxTw8yiSnLlClMK0K83hff5XHnkKDkw0OYM0ldWKsk/edit#slide=id.p1)\>  
+    * Homebrew provenance beta landed  
+    * RSTUF now incubating \- looking for funding for cloud credits \-  
+    * Draft guidance on trusted publishing   
+    * Participation in meetings? Period of decreased participation but it goes up and down.  
+    * Are there people in securing SW repos group tracking SLSA? Important for SLSA source track to work with different ways that people host sourcecode…  
+    * On trusted publishing \- A-O ⍺𝛀 and this wg should sync.  
+    * Paperwork / lifecycle stage ? \- they are the first wg to formally establish a lifecycle status \- they are graduated and paperwork up to date.  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * Staff update: Looking for an additional TAC member for SOSS Fusion CFP committee, contact Khahil  
+  * Best Practices WG has created & approved new guidance on Regular Expressions. A draft blog post about it here, please let us know about any issues in the blog post \- [https://docs.google.com/document/d/1nvlk-eAGdApbmDpKZDdBKYLvFEzBwLvs0wC2EjljAcQ/edit](https://docs.google.com/document/d/1nvlk-eAGdApbmDpKZDdBKYLvFEzBwLvs0wC2EjljAcQ/edit)  
+  * Have drafted security architecture course outline \- comments welcome in: [https://docs.google.com/document/d/1D\_IVQZ3P52vNnCreQF4D1r7rPp78C3xQIw2Nvo5Ss8s/edit](https://docs.google.com/document/d/1D_IVQZ3P52vNnCreQF4D1r7rPp78C3xQIw2Nvo5Ss8s/edit) \- will review outline in next Best Practices WG meeting on June 18 (10am ET)  
+* Issues for VOTE (list issue \#)  
+  * None this time  
+    * Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * Please flag any issues for voting for next meeting  
+*   
+  * Q2 TI Funding Review \-   
+    * [TAC Issue 311](https://github.com/ossf/tac/issues/311) \- Security Tooling contractors  
+      * Request for $50,000 to hire 1 dev contractor for 1 quarter  
+      * Q on costings … different skills / different costs… ;  
+      * Q on validation of demands…   
+      * Q is this scoped to a specific technical initiative? For this one, it will be for supporting one tool from any one of the TIs… And will get feedback from the TAC on which one…; but TAC is expected to evaluate the technical merit of the proposal… ;   
+      * … technically only incubating and graduating TIs are entitled to get this funding. So that limits the scope already.  
+      * Ryan: feels it’s not a blank check but a capped funding request \- and we need to do a survey of eligible TIs which could be time consuming. Trying to figure out how to get resources to places to places that don’t have resources…  
+      * Rob: … needs a more focused statement of work.  
+      * Omkhar: yes there is money available \- there is a budget committee meeting happening. If we’ve underspent the budget committee may choose to recoup. Could only select work that has a small maintenance work…  
+      * Ryan: some squeaky wheels have come forward but I’d like to do a survey and get feedback.  
+      * Arnaud: maybe pick something that will be helpful and go with that.  
+      * **\*\*we commit to getting engage with Ryan out of band to come to an up/down decision\*\***  
+    * [TAC Issue 315](https://github.com/ossf/tac/issues/315) \- RSTUF cloud credits  
+      * Request for 1,000 Euro for the 12mo period   
+      * Zach: They are part of the securing repos working group \- they are working on features to protect the integrity of ruby gems… RSTUF makes it harder to tamper with previous releases.  Will this become a recurring expense? No \- they are looking to get to a certain release milestone and then ruby gems will take this over. Not a recurring expense for 2025\.  
+      * Michael: seems reasonable  
+      * Omkhar: since funding is on an annual basis \- suggest constraining the request to the calendar year or pre-spending it in the calendar  year. \<- zach acknowledges  
+      * **\*\* recording 7 yes votes and 0 no votes and sarah said yes offline\*\* \- passes**  
+    *  [TAC Issue 328](https://github.com/ossf/tac/issues/328) \- S2C2F PAS request  
+      * Request for $4,000 to hire PAS contractor  
+      * Michael L: by and large makes sense … only concern is a singular focus on making this a standard at expense of community. We need to make sure that this is still in good standing. Maintainers still maintain project, multi-person involvement, etc. We want to ensure we have multiple organizations are involved\!  
+      * Arnaud: they are in an incubating state…   
+      * **\*\*general consensus that this is a good use of the money but we should defer / offline to give S2C2F a chance to address concerns\*\***  
+    * [TAC Issue 339](https://github.com/ossf/tac/issues/339) \- sigstore documentation modernization   
+      * Request for $50,000 to hire docs contractor  
+      * There’s been a number of languages added, need to make it holistic/consistent. SDKs expected to be static once done, so expect this to be a 1-time expense.  
+      * Arnaud: i support.  
+      * \[Ref previous issue on budget years\]  
+      * **6 yes (+2 offline), 0 no. Passes**  
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# **2024-05-28**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | ----- | ----- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | Bob Callaway (Google, **TAC**)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator & Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) | he/him | camaleon2016 |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Sarah Evans (Dell Technologies,**Governance Committee**, **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC**) | he/him | steiza |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Amanda Martin (LF) | she/her | hythloda |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | David A. Wheeler (Linux Foundation) |  |  |
+| x | Sally Cooper (LF) |  |  |
+| x | Omkhar Arasaratnam (LF) |  |  |
+| x | Angelah Liu (LF) |  |  |
+| x | Bennett Pursell (LF) |  |  |
+| x | Dana Wang (LF) |  |  |
+| x | Georg Kunz (Ericsson) |  |  |
+| x | Isaac Hepworth (Google, **SCI WG lead**) |  |  |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Justin Cappos (NYU, GB) | he/him | JustinCappos |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+| x | Aditya Mukherjee |  |  |
+| x | Madison Oliver (GitHub) | she/her | taladrane |
+| x | Jr Noble (South Metro Fire Rescue) | he/him |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Reden Martinez  
+* Determine TAC quorum  
+  *  We have TAC quorum. Daniel Appelquist and Marcela Melara cannot join today.  
+* Update homework/outstanding ARs  
+  *    
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  *  Supply Chain Integrity \- Isaac Hepworth  
+    * [Supply Chain Integrity WG](https://docs.google.com/presentation/d/1XSTdMPkSfonEPeGGovMOaKxgA0AMQ9k7mjrmT4vb5RM/edit#slide=id.p1) presentation  
+    * Isaac Hepworth outlines developments and initiatives within the Supply Chain Integrity working group, including current and incoming subgroups, new projects, and ongoing enhancements.  
+    * Would love to see more dogfooding on our own projects with other projects. Create a feedback loop inside ourselves to then launch externally.   
+    * CROB inquires about the timeline for filing life cycle paperwork for the SCI working group, and Isaac acknowledges this, planning to address it in a future TAC call.  
+  *  SOSS Updates \- Zach Steindler  
+    * [2024 May SOSS Updates](https://docs.google.com/presentation/d/18FZsStJwyeVRU9mmN6Eaoz6ZWIl98SQll_pLp5pdQtQ/edit?usp=sharing)  
+    * Note that these are not TIs but link the work  being done between the TIs  
+    * The taskforce serves as a collaborative platform for brainstorming and discussion, ultimately contribute to the work carried out in OpenSSF  
+    * Shout out to Adrianne for helping make these TF a success.   
+    * The Vulnerability Disclosure Working Group has been highly active, sponsoring the VulnCon security conference and organizing a cybersecurity incident response exercise. They launched the Siren mailing list for sharing intel post-vulnerability disclosure.  
+    * The Security Education Group, led by David Wheeler, released a state of education report and is developing new classes and an academic certification program. They seek contributors for hands-on labs to enhance their fundamentals class.  
+    * The goal is  to have the educational content taught at universities and community colleges by establishing a certification program, ensuring programs meet quality standards to receive LF certification  
+    * Justin Cappos is providing assistance on this. They are developing two new classes to supplement their existing fundamentals course. The first will target training developer managers, stressing basic cybersecurity concepts and addressing the heightened interest in security architecture revealed in the State of Security Education survey  
+    * Looking for people to make labs\!  
+    * Updates on LF Research re: survey \- The survey was completed in April, and analysis has been done in collaboration with LF Research. A final draft report summarizing the survey findings is nearly finished and will be released soon, pending review.  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  *  \[Zach\] Request for clarity on current state of funding requests  
+    * [https://github.com/orgs/ossf/projects/25](https://github.com/orgs/ossf/projects/25)   
+    * Can we close out [311](https://github.com/ossf/tac/issues/311), [314](https://github.com/ossf/tac/issues/314), [315](https://github.com/ossf/tac/issues/315)?    
+    * The review of the initiatives is scheduled for June 11th. It appears that the three currently in the queue were previously reviewed by the TAC. Pending approval, they will be moved to the TAC-approved status for further assessment by OpenSSF staff  
+    * Zach to ask Ryan Ware on his TI status /funding request  
+* Issues for VOTE (list issue \#)  
+  *  [TAC Issue 328](https://github.com/ossf/tac/issues/328) \- S2C2F PAS Submission Funding Request  
+    * Isaac is making an issue in the TAC repo to create a WG for specs  
+  * [TAC Issue 322](https://github.com/ossf/tac/issues/322) \- GitHub Enterprise Production Readiness Document Review \- Authentication, Authorization, Audit Log Ingestion, Monitoring and Alerting  
+    * Four points need reviewed & approved by TAC  
+  * [TAC Issue 292](https://github.com/ossf/tac/issues/292) \- OpenSSF GitHub Enterprise Account Structure and Shared Responsibility Model  
+    * Three points need reviewed & approved by TAC  
+    * TAC members to resolve any outstanding questions or comments on Issues 322 and 292 related to GitHub account configuration, and make the agreed-upon direction in a comment by end of business tomorrow (Eastern US time).  
+    * Dana, Arnaud, and Sarah to talk to bring the GitHub account configuration discussion to closure  
+    * Dana and Bennett to begin implementing the GitHub account configuration controls as described, in parallel with the ongoing discussion  
+        
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *   [TAC PR 332](https://github.com/ossf/tac/pull/332) \- RSTUF from Sandbox to Incubating  
+    * 6 of 9 TAC members have approved so far.  Welcome to Incubating RSTUF\!  
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# **2024-05-14**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | ----- | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | Bob Callaway (Google, **TAC**)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator & Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) | he/him | camaleon2016 |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC**) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies,**Governance Committee**, **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC**) | he/him | steiza |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Bennett Pursell (LF) |  |  |
+| x | David A. Wheeler (Linux Foundation) |  |  |
+| x | Sally Cooper (LF) |  |  |
+| x | Angelah Liu (LF) |  |  |
+| x | Jeffrey Borek (IBM) |  |  |
+| x | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) |  | jeffmendoza |
+| x | Xander Grzywinski (Defense Unicorns) | he/him | salaxander |
+| x | Aeva Black | they/them | AevaOnline |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+| x | Stephen Augustus (Cisco) | he/him | justaugustus |
+| x | Spencer  Schrock (Google) | he/him |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Reden Martinez  
+* Determine TAC quorum  
+  *  We have TAC quorum. Daniel can’t join today.  
+* Update homework/outstanding ARs  
+  *    
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Metrics and Metadata \-  Luigi Gubello   
+    * \<link to preso\>  
+  * Securing Critical Projects \- Amir Montazery and Jeff Mendoza  
+    * [May 14, 2024 Securing Critical Projects WG - TAC Update](https://docs.google.com/presentation/d/1l6VlRD4L4vUZ_6ogsBYTvRcfT0lZYpYE_O-0bdSksoQ/edit?usp=sharing)  
+    * Presented by Jeff Mendoza  
+    * The working group is focusing on defining critical projects by adding metadata for better filtering and sorting, allowing entities to identify projects they can best support. Recent efforts include brainstorming and narrowing down criteria like project size, support structure, and scorecard score. Updates on various projects were also discussed, including memory improvements in AllStar and progress in Criticality Scoring and Package Analysis.  
+    * Allstar moving into Scorecard as umbrella  
+    * Fewer people in meetings
+
+    
+
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  *  OpenSSF Best Practices badge vulnerability reports from Feb 2024\.  
+    * We received two simultaneous vulnerability reports of a secret checked into the repo, from reporter @arminru (Armin Ruech) and another reporter who did not want to be given named public credit.  
+    * This wasn’t a vulnerability, as we haven’t used the service in many years & the secret (key) is no longer valid.  
+    * However, this report led us to search for similar problems. We found one (for translation, though not used in production) & immediately fixed it. There’s no evidence this was ever exploited.  
+    * We’ve made changes to prevent similar problems in the future (enabled secret scanning & push protection).  
+    * We always want to learn from past problems and near-problems\!  
+    * Bennett Pursell will investigate enabling secret scanning & push protection for all OpenSSF projects (and possibly enable it). Would love to hear from TAC about this idea.  
+    * For details, see the TAC mailing list or [https://docs.google.com/document/d/1MWBTqpO8XofvN9ElTX5tPB8a7N1N0Wp9JgEQ9ff4Qvo/edit](https://docs.google.com/document/d/1MWBTqpO8XofvN9ElTX5tPB8a7N1N0Wp9JgEQ9ff4Qvo/edit)  
+    * Perhaps we should add this to our MVP [https://github.com/ossf/tac/issues/215](https://github.com/ossf/tac/issues/215)   
+    * Perhaps we should add this to: [https://best.openssf.org/SCM-BestPractices/\#recommendations](https://best.openssf.org/SCM-BestPractices/#recommendations)  
+      * David agreed that this was a good idea, and created an issue proposing this [https://github.com/ossf/wg-best-practices-os-developers/issues/488](https://github.com/ossf/wg-best-practices-os-developers/issues/488)  
+    * Plan to scan FIRST, then once it looks okay, THEN add push protection.  
+    * Jeff: You can set defaults for new projects, that’s another good thing to modify first.  
+* Issues for VOTE (list issue \#)  
+  * None this week  
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *   [TAC PR 319](https://github.com/ossf/tac/pull/319) \- TAC Decisioning Process  
+    * TAC agreed to merge the PR with changes to “major” category.  Will continue to iterate and improve in the future  
+    * Future items to consider would be how to handle “no” votes and “approval with notes/pending changes”  
+  *  [TAC Issue 325](https://github.com/ossf/tac/issues/325) \- Projects reporting structure  
+    * If the WGs don’t add much value to a project/SIG, they may want to work directly under the TAC to reduce the number of steps, but that would overwhelm the TAC  
+    * Scaling questions \- how do we handle scale?  
+    * CRob: I encourage WGs be led by co-chairs, that seems to be very effective.  
+    * Arnaud: We need a rationale for something reporting directly to the TAC instead of a WG. Generally we want to push it down, not report directly to the TAC. Perhaps document expectations.  
+      * What does it mean for a WG to have projects/SIGs? Basically, at the least, projects/SIGs must report to their WG, and those WGs must report to TAC. Document that\!  
+      * CRob: We do have a stub in the roles & responsibilities document.  
+    * Probably should encourage all WGs to have a “template” of their meeting notes that includes the list of their projects & SIGs, for them to report up changes & current state. Don’t need to hear every little detail, but this would provide a mechanism for WGs to routinely get updates on their projects & SIGs  
+* Updates on older matters   
+  *   
+  *    
+  *   
+* AOB  
+  * None this week
+
+# **2024-04-30**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+| x | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+| x | Bob Callaway (Google, **TAC**)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) | he/him | camaleon2016 |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC**) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC**) | he/him | steiza |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+| x | Jeffrey Borek (IBM) | he/him | jtborek206 |
+| x | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) | he/him | jeffmendoza |
+| x | Ryan Ware (Intel, **Tooling WG Lead**) | he/him | ware |
+| x | Seth Larson | he/him | sethmlarson |
+| x | Mihai Maruseac (Google, **AI/ML WG co-lead**) | he/him | mihaimaruseac |
+| x | Xander Grzywinski (Defense Unicorns) | he/him | salaxander |
+| x | Aeva Black | they/them | AevaOnline |
+| x | Neal McBurnett | He/him | Independent |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Amanda Martin (LF) | she/her | hythloda |
+| x | Angelah Liu (LF) |  |  |
+| x | Bennett Pursell (LF) |  |  |
+| x | Dana Wang (LF) |  |  |
+| x | David A. Wheeler (LF) |  |  |
+| x | Harry Toor (LF) |  |  |
+| x | Omkhar Arasaratnam (LF) |  |  |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Sally Cooper (LF) | she/her |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Reden  
+* Determine TAC quorum  
+  *  We have quorum, in fact, we have every TAC member 9/9  
+* Update homework/outstanding ARs  
+  * Posted notes from 16 April TAC F2F meeting  
+    * Review outstanding funding requests  
+      * **Project View:** [https://github.com/orgs/ossf/projects/25](https://github.com/orgs/ossf/projects/25)   
+      * [TAC Issue 265](https://github.com/ossf/tac/issues/265) \- DEI WG GUAC intern \- closed/approved  
+      * [TAC Issue 311](https://github.com/ossf/tac/issues/311)\- Tooling Wg contractor \- approved  
+      * [TAC Issue 314](https://github.com/ossf/tac/issues/314) \- RSTUF stickers \- closed/denied  
+      * [TAC Issue 315](https://github.com/ossf/tac/issues/315) \- RSTUF cloud credits \- closed/denied \- sandbox  
+    * Review Dana’s [TAC Issue 292](https://github.com/ossf/tac/issues/292) \- OpenSSF Github Enterprise Account structure and shared responsibility model  
+    * Review Dana’s [TAC Issue 215](https://github.com/ossf/tac/issues/215) \- Security MVP & the associated   [OpenSSF Security MVP Draft](https://docs.google.com/document/d/1-NBXdKvEJ9Wsh2i7lDNYven4fY9Bn6uvNJM5ySlMrdg/edit)  
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * AI / ML WG \- Mihai Maruseac and Jay White,  
+    * [April 30, 2024 AI/ML WG - TAC Update](https://docs.google.com/presentation/d/1818rjfFrbcoNol_norfXd_YhSpdDbU2dadbwwoLcMCI/edit#slide=id.p1)  
+    * When will the WG complete their [lifecycle](https://github.com/ossf/tac/blob/main/process/working-group-lifecycle.md) PR?  
+    * New SIG on model signing   
+    * Is there a roadmap of action items for the WG to focus on? How can others help the group.   
+      * Too early for threat modeling  
+    * New groups involved in OSS & AI/ML are constantly springing up. That said, trying to interact with many. Many LF; OWASP; etc.  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * Omkhar \- CISA Secure By Design Pledge (this document is NOT currently public)  
+    * Pledge includes follow activities to be measurably improved over next year:  
+      * Implement MFA  
+      * Reduce default passwords  
+      * Reduce entire classes of vulns     
+      * Increase consumer installation of security patches  
+      * Publish a VDP  
+      * Transparently report CVEs  
+      * Enable customers to gather evidence of cybersec intrusions affecting products  
+    * How do we separate the member companies signing vs projects signing.  
+      * The pledge seems rather tactical and might be distracting from the MVS  
+      * There doesn’t seem to be much difference between this and the Best Practices  
+      * The pledge is a good thing however we are already doing similar work  
+      * This blurs our standing of being the ones that encourage best practices and the ones that deliver tools  
+      * What does it mean if we sign vs endorse the pledge  
+      * **ACTION**: CRob to get TACs thoughts in word format by EOD.   
+    * SOSS [Happy Hour](https://web.cvent.com/event/c2e0fdf9-2734-458d-818d-fd0460b45c55/summary) at RSA   
+* Issues for VOTE (list issue \#)  
+  *    
+    *   
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+* [TAC Issue 308](https://github.com/ossf/tac/issues/308) \- Alignment between lifecycle and staff \-  *15min*  
+  * Proposal  
+    * WGs get staff support for standing meetings (meeting notes, agenda building, backlog review, …..  
+    * Incubating Projects may request the above as it is available  
+    * Other TIs may request ad hoc support as it is available  
+    * TAC Meeting will have assistance in data collection, communications, backlog management, …..  
+    * Generally, Graduated TIs should receive the majority of staff support  
+    * Any valid group may request ad hoc services (arch review, as example).  Prioritized as above based on stage of lifecycle  
+    * Question on how the current gives/gets needs more details.   
+    * Need to get help with tracking and metrics to see how things are progressing.   
+    * This goes into two buckets, that which we are already doing and that which we want to have down.   
+    * ACTION: Omkhar to create a list of what each WG will be getting and prioritize as needed.   
+  *  [TAC Issue 317](https://github.com/ossf/tac/issues/317) & [TAC PR 319](https://github.com/ossf/tac/pull/319) \- TAC Decision Documentation  
+    *  Need more time for some TAC members to review  
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# 2024-04-16
+
+**OSS-NA 2024 TAC F2F**  
+The TAC will be meeting in Seattle, WA on Tuesday **April 16, 2024 from 1-3pm PT**.  This will allow us real-time collaboration time to help drive some ongoing and new topics ideally closer to delivery.   
+
+### Agenda
+
+## Marketing & Messaging of OpenSSF TIs
+
+| zs | crr | sje | bc | msm |  |  |  |  |
+| :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- |
+
+* Facilitator \- Zach Steindler  
+* We are getting raked over the coals by the infosec community  
+  * [https://openssf.slack.com/archives/C019M98JSHK/p1711980515748459](https://openssf.slack.com/archives/C019M98JSHK/p1711980515748459)   
+  * [https://openssf.slack.com/archives/C034CBLMQ9G/p1712239611366269](https://openssf.slack.com/archives/C034CBLMQ9G/p1712239611366269)   
+  * [https://infosec.exchange/@joshbressers/112235581764225489](https://infosec.exchange/@joshbressers/112235581764225489)   
+  * [https://openssf.slack.com/archives/C0235AR8N2C/p1712670458533749?thread\_ts=1712669222.032019\&cid=C0235AR8N2C](https://openssf.slack.com/archives/C0235AR8N2C/p1712670458533749?thread_ts=1712669222.032019&cid=C0235AR8N2C)  
+* How do we help TIs crisp up their messaging on what they are offering, and what they aren’t offering?  
+* How do we engage in community discussions (happening \*outside\* the OpenSSF) without feeding the trolls.  
+* Z \- we should feel less afraid to attend other WG/TIs outside of our current space.  Go to new places an share feedback. Help ensure community feedback is getting into the groups.    
+* Z \- call to action \- during GH ospo review of scorecard, questions and feedback came up  
+* D \- “ambulance chasing” feeling around XZ blog. “Just using this to push your thing.” …in the of the crisis.  Don’t imply Tool X would fix the thing  
+* M \- there will always be trolls.  OpenJS blog had different reaction  
+* B \- we have a process to manage these blogs, it obviously was not followed.  It is understandable that we need to react quickly, but we need to better balance.  
+* J \- avoid bandwagon jumping, we need to keep the maintainer in mind.  What could we do better to keep maintainers in mind and help them?  
+* Z \- is there a postmortem setup?   
+* B \- new mailing list blog xp was good.  If there is urgency, we can react quickly  
+* Harry \-volunteers O  
+* Z \- the 2nd “xz post” has been received much better. Are we writing these learnings down so that future tac’s can leverage it  
+* B \- GH postmortem was a good example, we should do more of that\!\!  
+* S \- do we need a “one voice” vs. separate ti voices  
+* CRob \- it is best practice in crisis comms to have that “one voice”, but for less critical, informal things the diversity of the community is valued  
+* Harry \- we’re “tooled” for “the consumer”, “the maintainer” doesn’t pay the bills  
+* Bob \- the purpose of the TAC is to help balance those personas, we’re more than happy to dive in and give feedback  
+* Z \- expanding the TAC allows for possibility that more people will be available to assist  
+* Bob \- TAC 313 \- MAC relations \- India Community/PINNY \- are .we raising awareness that this exists, or are we implied endorsement.  It seems very disconnected  
+* J \- PINNY is a symptom of the problem; how do we better interlock with them?  
+* B \- we have historically gotten feedback that we have not had good project governance.  These “flare ups” help chip aware of the public perception we’re well-managed.  It feels like we have disjointed efforts  
+* A \- it is ok to refer to things outside of OSSF, but things need to be clearly delineated this is not officially part of us  
+* B \- would like to see the energy spent reacting to “PINNY” would be better spent amplifying those good works  
+* S \- doesn’t tink we need to have a synchronous engage, but there needs to be some kind of guidance/gating   
+* M \- we need an understanding of who to reach out to on the MAC.  There is lack of clarity between roles & resp.  
+* This should be put into a policy & procedures document.  S \- does the MAC have a P\&P?    
+* Z \- this is a new thing, we’re all maturing  
+* M \- how was the MAC formed to be so large?  Harry \- the membership was changed to allow for general/associate members.  The marking review group was set up to help achieve that objective of the gb desire to monitor brand.  
+* DECISION \- we will work with the MAC and setup that all “committee” chairs will get notice on blogs \[TAC, GB, GC, MAC\]; TAC agrees that TAC-private list will be the how we help with the review  **@CRob \- talk with Katharine and Tracy to instantiate this with the blog review process**  
+
+## Putting the “T” in TAC
+
+| zs | mbl | sje | msm |  |  |  |  |  |
+| :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- | :---- |
+
+* Facilitator \- Zach Steindler  
+* in-toto documents as interchange between security / supply chain tooling?  
+* Is there technical guidance we should be giving projects on what to do?  
+  * Or what *not* to do?  
+* (this could also overlap with [R in MSVR](https://docs.google.com/document/d/1nukiyb-XVBSR_TjMBKcRWf4b9BNDzFNI2gdstmVomg8/edit#heading=h.mk2bj4rvbjv8))  
+* Is there documentation/guidance that could be developed to help steer using our [technical vision](https://github.com/ossf/tac/blob/main/technical-vision.md) ?  
+* Z \- most of the time I’ve spent in the past year has been spent on P\&P, lifecycles, and funding procedures  
+* Z \- good that we have this all evolving, but this “is not the work I was expecting”  
+* Z \- are we about to be “done” with P\&P, or will we get to meaningful capital-T technology questions?  
+* Z \- what sort of things do we want to focus on as the TAC from a technology perspective? There are ways to delineate the problem (product management, design, marketing, tech debt)  
+* D \- I share some of your concerns around focus on policies, it was appropriate relative to the maturity of the foundation. We should be “dialing it back a bit” now  
+* D \- the TAC should be doing more to guide projects & WGs in the OpenSSF to work together; frustration that we get updates from WG / projects, but TAC is not providing substantive feedback at the moment (help people work together)  
+* C \- \+1 to Dan’s comments, I’ve tried to get pre-read discussions to folks ahead of time  
+* D \- could we swap the structure so that they have to update an GH issue to provide the data instead of a presentation?  
+* A \- I’ve suggested this before; updates can be mostly asynchronous via a PR template, so that during the synchronous meeting, we can focus on contentious issues or relevant points of discussion  
+* A \- We could be spending time to fix some of the hierarchy, grouping/structure of WG, projects, etc \- recruiting other projects and filling gaps  
+* ML \- Are we looking at the grouping or collection of common things to drive alignment?  
+* A \- In Hyperledger, the TAC members are asked to LGTM the PRs   
+* S \- if we’re making changes, should we ask a question about where the TI is partnering and where they need help?  
+* A \- Use this to drive awareness of “conformance” to foundation-wide standards  
+* Harry \- All our projects don’t have SBOMs, LFX Insights is a good tool, how do we use these sort of tools to make advisory recommendations to drive greater adoption & success?
+
+# **2024-04-02**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---- | :---- |
+| x | **Arnaud Le Hors (IBM, TAC)** | he/him | lehors |
+| x | **CRob (Intel, BEST WG facilitator & Vuln Disc facilitator, End User WG, TAC)** | he/him | SecurityCRob |
+| x | **Daniel Appelquist (Samsung, TAC)** | he/him | torgo |
+| x | **Jay White (Microsoft, AI/ML WG Lead, DEI WG Lead, TAC)** | he/him | camaleon2016 |
+| x | **Michael Lieberman (Kusari, TAC)** | he/him | mlieberman85 |
+| x | **Marcela Melara (Intel, TAC)** | she/her | marcelamelara |
+| x | **Sarah Evans (Dell Technologies, Toolbelt Co-Lead, TAC)** | she/her | sevansdell |
+| x | **Zach Steindler (GitHub,TAC)** | he/him | steiza |
+| x | Jacques Chester (independent, **End User WG co-lead**) | he/him | jchester |
+| x | Michael Scovetta (Microsoft, **Alpha-Omega, ID Security Threat WG lead**) | he/him | scovetta |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Kenny Paul (LF) | he/him | KennyPaul |
+| x | Reden Martinez (LF) | he/him | redenmartinez |
+| x | Bennett Pursell (LF) |  |  |
+| x | David A. Wheeler (Linux Foundation) |  |  |
+| x | Dana Wang (LF) |  |  |
+| x | Harry Toor (LF) |  |  |
+| x | Sally Cooper (LF) |  |  |
+| x | Omkhar Arasaratnam (LF) |  |  |
+| x | Georg Kunz (Ericsson) |  |  |
+| x | Jeffrey Borek (IBM) | he/him |  |
+| x | Karen Bennet (IEEE) | she/her |  |
+| x | Seth Larson (PSF) | he/him | sethmlarson |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+| x | Aeva Black (CISA) | they/them | AevaOnline |
+| x | Madison Oliver (GitHub) | she/her | taladrane |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Kenny  
+* Determine TAC quorum  
+  *  ✅  
+* Update homework/outstanding ARs  
+  *   [TAC PR 298](https://github.com/ossf/tac/pull/298) \- has come conflicts that need addressed prior to merging  
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * BEST WG \- CRob+Randall  
+    * [\<link to preso\>](https://docs.google.com/presentation/u/0/d/1XjaJa2yxWgRmXhpv0N1_oPG23JPpJY_9zpSOMvqccUM/edit)  
+    * Liked the supply chain slides so adopted that model  
+    * Edu.SIG \-   
+      * Survey underway on dev security practices [LINK](https://www.research.net/r/9TGV738)  
+      * Collaboration w/ NYU and others on curriculum development  
+      * Draft for manager training   
+      * NEED: please take the surrey  
+    * Mem Safety Sig  
+      * Drafted a new doc in the repo \- looking for reviews  
+      * Will be hosting a workshop to improve mem safety. \- IT funding PR underway  
+    * Best Practices  
+      * Working through the lifecycle process \- please work with David if you are a project to get you badges going  
+      * best.openssf.org for lab access  
+    * Security Toolbelt  
+      * Looking at “weekend warrior” persona   
+      * Considering in-toto as the “protocol” for the control plane  
+    * Q for TAC \- has your org incorporated training into your education?  
+  *  End User WG \- Jacques  
+    * [\<link to preso\>](https://docs.google.com/presentation/d/1UOa7O2-J00YoW-MyeDUILKplyCmJ5nQX_4HxZGdJ_Ig/edit#slide=id.p1)  
+    * Charter has been addressed  
+    * Threat Modeling  
+      * Paused for a moment \- need reviewers for the draft doc please.  
+    * Q for TAC \- looking for introductions that can help grow the WG across geos.  
+      * Mike- also interested in how we can help end users  
+    * The threat modeling doc basically highlighted issues that contributed to the XZ issue  
+    *   
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * OSS-NA coming up  
+  * Harry \- looking for a happy  hour after community day  and something at RSA  
+  * David: Here's the list of "labs we'd like to have": [https://best.openssf.org/labs/](https://best.openssf.org/labs/)  \- examples of what you SHOULD do that are short are clear would be wonderful.  
+  * Omkhar- after a year working on making things better one of the processes is a post-mortem \- this is blameless although you will see names.    
+  *  [TAC Issue 304](https://github.com/ossf/tac/issues/304) \- GitHub post-mortem- Dana \- 20min  
+    * Michael- [https://sre.google/sre-book/postmortem-culture/](https://sre.google/sre-book/postmortem-culture/)  🙂  
+    * Broad access and lack change management contributed to the issue  
+    * moving to GHE created a larger opportunity for the issue  
+    * Change that was made caused github actions to pause for \~10 mins  
+    * No suspicious activity from co-pilot identified  
+    * Exploring approach to restrict admin roles without impacting projects and tooling  
+    * Put a manual log review in place. \- looking at automation options w/ LF-IT and datadog  
+    * Optimizing the role design for GHE \- have reached out to GitHub for recommendations \- will return to the TAC with this in a couple of weeks.  
+    * Positives \- identified quickly  
+    * Negatives \- lack of process rigor and auth controls  
+    * Got Lucky \- no suspicious activity, didn’t encounter expensive services being used.  
+    * Zach \- impressed about the lifecycle of this event and net results \- pleased with the response to the incident  
+        
+* Issues for VOTE (list issue \#)  
+  * Nothing this week  
+  * Please flag any issues for voting for next meeting
+
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * VulnCon 2024 \- OpenSSF was a sponsor and had 11 speakers present on assorted aspects of oss security to the broader vuln ecosystem  
+    * Thank you to the foundation for sponsoring and thank you to all of our amazing members that participated and shared their knowledge\!  
+    * All\* videos will be publicly available on the FIRST and CVE YouTube channels in \~1month  
+    * Blog recap \- [https://openssf.org/blog/2024/03/29/vulncon-2024-wrap-up-securing-the-ecosystem-through-global-cooperation/](https://openssf.org/blog/2024/03/29/vulncon-2024-wrap-up-securing-the-ecosystem-through-global-cooperation/)   
+    * Would like to see OpenSSF’s continued support of this even in 2025
+
+  * TI Funding process now open for submissions  
+    * [https://github.com/ossf/tac/blob/main/process/TI%20Funding%20Request%20Process.md](https://github.com/ossf/tac/blob/main/process/TI%20Funding%20Request%20Process.md) 
+
+  * S2C2F to submit to JDF \- Jay  
+    * Opened an issue on this: [TAC Issue 305](https://github.com/ossf/tac/issues/305)  
+    * Didn’t have a process for pursuing an international standard   
+    * Plan is to submit for JDF engagement  
+    * For TACs awareness that this it taking place  
+    * Zach- pleased to hear this \- Does TAC need to approve submission for a specification \- Non blocking request to open an issue on the   
+      * Jay that is the issue noted above  
+    * Michael \- think that process should be in line with release notification process \- may want to look at other orgs  
+      * Jay \- many different standards orgs out there \- start at home with JDF before looking externally  
+    * Arnaud \- standards bodies do compete with each other 🙂 \- we can decide on a case-by-case basis based upon domain of expertise. \- don’t want to see a complex process, but probably not much beyond a checklist  
+    * CRob \- lightweight process and we should definitely provide guidance   
+    * David \- provide very simple process \- don’t believe the GB needs to be involved \-  Terminology clarification \- we are talking about formal standards only  
+* Updates on older matters  
+  *   
+* AOB  
+  * None this week
+
+# **2024-03-19**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---- | :---- |
+| x | **Arnaud Le Hors (IBM, TAC)** | he/him | lehors |
+| x | **CRob (Intel, BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC)** | he/him | SecurityCRob |
+| x | **Daniel Appelquist (Samsung, TAC, Best WG, End User WG)** | he/him | torgo |
+| x | **Jay White (Microsoft, AI/ML WG Lead, DEI WG Lead, TAC)** |  |  |
+| x | **Marcela Melara (Intel, TAC)** | she/her | marcelamelara |
+| x | **Zach Steindler (GitHub,TAC)** | he/him | steiza |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Reden Martinez (LF) | He/him | redenmartinez |
+| x | Bennett Pursell (LF) |  |  |
+| x | David A. Wheeler (Linux Foundation) |  |  |
+| x | Jennifer Bly (LF, OpenSSF) |  |  |
+| x | Angelah Liu (LF, OpenSSF) |  |  |
+| x | Sally Cooper (LF, OpenSSF) |  |  |
+| x | David Edelsohn (IBM, **CTI co-lead**) |  |  |
+| x | Georg Kunz (Ericsson) |  |  |
+| x | Michael Scovetta (Microsoft, **Alpha-Omega, ID Security Threat WG lead**) |  |  |
+| x | Luigi Gubello (Pitch) |  | luigigubello |
+| x | Rodrigo Capeao |  |  |
+| x | Madison Oliver (GitHub, **Vuln Disclosure WG co-chair**)  | she/her | taladrane |
+| x | Siddhesh Poyarekar |  |  |
+| x | A S M Shamim Reza |  |  |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Adrianne Marcum  
+* Determine TAC quorum  
+  *  6 of 9 in attendance, we have quorum  
+* Update homework/outstanding ARs  
+  * Lifecycle PRs (from the department of this meeting could have been an email)  
+    * Incubating  
+      * [TAC PR 277](https://github.com/ossf/tac/pull/277) \- WG incubating criteria  
+        * @Arnaud, @Bob, @Daniel,@Marcela, @Mike  
+      * Graduated  
+        * [TAC PR 281](https://github.com/ossf/tac/pull/281) \- SIG graduation criteria  
+        * @Arnaud,  @Bob, @Daniel, @Jay, @Zach  
+    * TAC members: Please review\!  
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * DEI \-  Jay White  
+    * \<[link to preso](https://docs.google.com/presentation/d/12Ns3JfwtwREJuuT3OCsCaUVeiLmifaPTo-PN07AUD4s/edit?usp=sharing)\>  
+    * Please file PR to denote lifecycle stage DEI WG is at: [https://github.com/ossf/tac/blob/main/process/working-group-lifecycle.md\#working-group-creation-or-change-of-lifecycle-stage](https://github.com/ossf/tac/blob/main/process/working-group-lifecycle.md#working-group-creation-or-change-of-lifecycle-stage)   
+    * Short & sweet\! TLDR: Working on application for incubating stage  
+    * Attendance low, \~ 5 regular attendance, 3 are TAC members  
+    * Working on 30/60/90 roadmap to share during panel discussion at SOSS CD NA  
+    * Hosting office hours to attract and support new talent interested in security careers  
+    * Q: Are there strategies to gain more attendance and engagement? How do we get the word out and keep momentum going?  
+      * There is a misconception that folks have to be part of a member organization to participate in technical initiatives  
+      * Meeting times can also be an issue, but those can be adjusted as needed for the community members that want to join a given initiative  
+  * Alpha-Omega \- Mike Scovetta  
+    * \<[link to preso](https://docs.google.com/presentation/d/1uxQs8B3Q2_rMPhkXYVYy2K6EXPnJ34p1yRSzTQsgwsY/edit?usp=sharing)\>  
+    * [TAC Issue 152](https://github.com/ossf/tac/issues/152) \- can we get this resolved please?  
+    * Please file PR to denote lifecycle stage A-O is at: [https://github.com/ossf/tac/blob/main/process/project-lifecycle.md\#submission-process](https://github.com/ossf/tac/blob/main/process/project-lifecycle.md#submission-process)   
+    * In 3rd year, updated participation agreed with same 3 participants (single fund)  
+    * Additional $3.2M funding from Microsoft  
+    * Leadership team remains the same, OKRs established to drive progress in 2024  
+      * Catalyze secure software for all major OS ecosystems through staffing  
+      * Top 10k OS projects are free of critical security vulnerabilities  
+      * Enhance A-O’s effectiveness in driving security improvements through deliberate innovation and experimentation  
+      * Run an operationally efficient and effective program  
+    * New and Renewed Funding, monthly updates  
+    * April 3 Community Meeting  
+    * April 17 A-O Roundtable at OSS NA  
+    * Request from the TAC: more engagement from the TAC. What does that TAC want to see?  
+    * Request: can A-O help resolve [TAC \#152](https://github.com/ossf/tac/issues/152)?  
+    * Is A-O a special type of group or should there be a process defined for this type of group/fund?  
+      * Different situation than a standard TI because funding comes from only 3 companies  
+      * GC has proposed solidifying the definition of a directed fund, but A-O is working as is regardless of governance   
+  * CTI \- David Edelsohn & Carlos O’Donnell \- Siddhesh will be playing the part of Carlos in this update  
+    * \<[link to preso](https://docs.google.com/presentation/d/1iuze0ESwX-iSj4M337vqfgVUz_v49fmnikfsh1NtJM0/edit?usp=sharing)\>  
+    * Please file PR to denote lifecycle stage CTI is at: [https://github.com/ossf/tac/blob/main/process/project-lifecycle.md\#submission-process](https://github.com/ossf/tac/blob/main/process/project-lifecycle.md#submission-process)   
+    * Improve the security posture of the GNU Toolchain components (gcc, binutils, glibc, gdb)  
+    * March: CTI website launched with documentation to resolve conditional vote  
+    * April: Start migration planning process with LF IT services  
+    * Isolating all services in VMs or containers to improve security and reduce interference; allow volunteers to focus efforts outside of core infra maintenance  
+    * Community engaged in defining security.md policy documents  
+    * glibc is now a CNA  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10  min* **MAX**  
+  * Welcome to Sally Cooper on the Linux Foundation marketing team supporting OpenSSF\! Sally and Angelah Liu will be taking on Marketing and Communications for OpenSSF while Jennifer Bly is on maternity leave  
+  * [SOSS Community Day](https://events.linuxfoundation.org/soss-community-day-north-america/) North America \- Seattle \- April 15th \- [Marketing kit for attendees to help spread the word](https://drive.google.com/drive/folders/1PrrSmZ8-K4WMMUgfqiw7CTZcMYnP_llO?usp=drive_link)  
+  * OSS-EU \- CFP now open\!  Vienna \- Sept 16-18 \-   
+    * [https://events.linuxfoundation.org/open-source-summit-europe/](https://events.linuxfoundation.org/open-source-summit-europe/)  
+  * SOSS\*Fusion \- CFP open now\! \-  ATL \-Oct 22-23 \-   
+    * [https://events.linuxfoundation.org/soss-fusion/](https://events.linuxfoundation.org/soss-fusion/)   
+* Issues for VOTE (list issue \#)  
+  *  Nothing this week  
+    *   
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * TI Funding process \- *10min:*  
+    * [https://github.com/ossf/tac/blob/main/process/TI%20Funding%20Requst%20Process.md](https://github.com/ossf/tac/blob/main/process/TI%20Funding%20Requst%20Process.md)   
+    * [https://github.com/ossf/tac/issues/257](https://github.com/ossf/tac/issues/257)   
+    * Is there a defined approval cycle?  
+      * Nothing set in stone yet and approval time will vary by request type and amount  
+      * May need to work out initial submission deadline and decide if a more flexible approach works long term  
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# **2024-03-05**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---- | :---- |
+| x | Arnaud Le Hors (IBM, TAC) | he/him | lehors |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC**) |  |  |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC**) |  |  |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Amanda Martin (LF) | she/her | hythloda |
+| x | Jennifer Bly (LF, OpenSSF) |  |  |
+| x | Georg Kunz (Ericsson) |  |  |
+| x | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) | he/him | jeffmendoza |
+| x | Luke Hinds (**sigstore lead**) |  |  |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+| x | Madison Oliver (GitHub, **Vuln Disclosure WG co-chair**) | she/her | taladrane |
+| x | Kenny Paul (Linux Foundation) |  |  |
+| x | Adolfo García Veytia (Stacklok/SIG OpenVEX Lead) | he/him/él | puerco |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Kenny Paul  
+* Determine TAC quorum  
+  * CRob sends regrets (In WDC this week)  
+  * BobC sends regrets (also in DC)  
+* Update homework/outstanding ARs \- ***5min total***  
+  * \[Sarah\] \-  [TAC Issue 256](https://github.com/ossf/tac/issues/257) \- Business case for fund application  
+    * [https://docs.google.com/document/d/1v8RovfUGRjZUy8CkwL-tsK1Gqe9W32g5gOj88vk4-a4/edit](https://docs.google.com/document/d/1v8RovfUGRjZUy8CkwL-tsK1Gqe9W32g5gOj88vk4-a4/edit) reviewed  
+      * Would likely become a google form  
+      * Timeline reviewed   
+      * April 1-5         TAC proposal review desired  
+      * [https://github.com/ossf/tac/pull/272](https://github.com/ossf/tac/pull/272)   
+      * \[Mike\] would like to see some threshold for a $ amount request \- concern is too much process inhibiting folks from applying  
+      * \[Sarah\] there is more process that needs to be works and that is one of them  
+      * \[Marcela\] Need to include what types of requests are qualifiers for this funding.  
+          
+    * \[Mike\] \- [TAC Issue 244](https://github.com/ossf/tac/issues/244) / [TAC PR 267](https://github.com/ossf/tac/pull/267) \- Provide guidance for projects maintained by a single organization looking to submit to OSSF Sandbox/ Build a community  
+      * Questions from potential new projects on how to grow a community \- should leverage whatever documentation is available to build a community
+
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Sigstore  
+    * [https://docs.google.com/presentation/d/16sRyvO0wnQPJFRndDUJCIPFW-vCsww5UzUHgt26G-c8/edit\#slide=id.g26067176131\_0\_7](https://docs.google.com/presentation/d/16sRyvO0wnQPJFRndDUJCIPFW-vCsww5UzUHgt26G-c8/edit#slide=id.g26067176131_0_7)   
+    * \[Luke\] Reviewed the deck  
+    * Graduated project now.1st project to reach that stage :-)   \- Process worked well  
+    * SIG-ops provides a 24/7 oncall rotation community staffed \- looking for a vendor to pick this up  
+    * No TAC asks at this time  
+    * \[Mike\] Q on memory safe implementation \- A using rust library FFI based  
+  * Vulnerability Disclosures  
+    * [Mar 05 2024 Vulnerability Disclosures WG - TAC Update](https://docs.google.com/presentation/d/1uSVAdO0QN8KItM_0sYcwsoNiKytM1Sa0effEPL_fNaw/edit?usp=sharing)  
+    * [https://docs.google.com/presentation/d/1uSVAdO0QN8KItM\_0sYcwsoNiKytM1Sa0effEPL\_fNaw/edit?usp=sharing](https://docs.google.com/presentation/d/1uSVAdO0QN8KItM_0sYcwsoNiKytM1Sa0effEPL_fNaw/edit?usp=sharing)   
+    * \[Madison Oliver\]  reviewed the deck  
+    * Will be applying for Graduated status soon  
+      * Recommendation to look at [Sigstore PR](https://github.com/ossf/tac/pull/273) for possible guidance on how to   
+    * Q {Sarah\] How can a project find out how to enable a VEX feed? \- \[Adolfo\] should be able to provide details shortly.   
+    * Also recommend working it Dana to get it included in the broader adoption  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *5min* **MAX**  
+  * \[Jennifer\] &\[Angelah\] covered the content  
+  * OSS-NA \- SEA \- April 15-18 \- [https://events.linuxfoundation.org/open-source-summit-north-america/](https://events.linuxfoundation.org/open-source-summit-north-america/)   
+    * TAC meeting scheduled during this week \- should be able to cancel this meeting  
+  * OSS-EU \- CFP now open\!  Vienna \- Sept 16-18 \- [https://events.linuxfoundation.org/open-source-summit-europe/](https://events.linuxfoundation.org/open-source-summit-europe/)  
+    * TAC meeting scheduled during this week \- need to think about status of this meeting   
+  * SOSS\*Fusion \- CFP open now\! \-  ATL \-Oct 22-23 \-  [https://events.linuxfoundation.org/soss-fusion/](https://events.linuxfoundation.org/soss-fusion/)   
+  * Do you have items you think would be good to include in our upcoming press release for April 15th at the start of SOSS Community Day NA? Please let the OpenSSF team know.  
+  * Now accepting applications for participants for the TTX at SOSS Community Day NA: [https://events.linuxfoundation.org/soss-community-day-north-america/program/ttx/\#overview](https://events.linuxfoundation.org/soss-community-day-north-america/program/ttx/#overview)   
+  * Registration is open for our first Tech Talk of the year on Scorecard on Wed. March 13th at 10AM PT. Register now \- [Building a Stronger Open Source Ecosystem: OpenSSF Scorecard Tech Talk](https://openssf.org/resources/tech-talks/building-a-stronger-open-source-ecosystem-openssf-scorecard/)  
+* Issues for VOTE (list issue \#)  
+  * Discuss following two requests so that as Funding process & bus. Case is complete we can act quickly on these two  
+  *  [TAC Issue 265](https://github.com/ossf/tac/issues/265) \- \[Funding Request\] DEI WG Proposal \- Outreachy intern for GUAC \- *10min*  
+    * \[Jeff\] covered the content   
+    * Request is for $8K to fund an intern \- missed the summer window,seeking approval for southern hemisphere summer session  
+    * \[Arnaud\] would like to see vote in GitHub  
+    * \[Jay\] support this is inline with the DEI-wg and would liek to see this as an ongoing thing  
+    * \[Sarah\] comfortable with a vote but do   
+    * **VOTE  motion Arnaud to support the request for funding  \- Zoom vote taken  and approved unanimously with 6 votes**  
+  * [TAC Issue 266](https://github.com/ossf/tac/issues/266) \- GUAC PoC cloud credits \- *10min*  
+    * \[Mike\] suggest taking any funding requests on an adhoc basis while the process is being set up  
+    * \[Sarahj\] want to ensure there is a cap on this for the POC  
+    * \[Mike\] can set the limits \- would like to see $1k per month  
+    * \[Sarah\] is this for a more public service \- A): not really- mainly “can this scale” and is the correct data being provided  
+    * \[Sarah\] would like to understand what the milestones are \- A) can highlight the milestones  
+    * Only authorized POC users ca use  
+    * **VOTE motion Arnaud to support the request for funding  \- Zoom vote taken  and approved unanimously with 6 votes**  
+    *   
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *     
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# **2024-02-20**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---- | :---- |
+| x | Arnaud Le Hors (IBM, TAC) | he/him | lehors |
+| x | Bob Callaway (Google, TAC)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) |  |  |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, TAC) |  |  |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC, GB observer, GC**) | she/her |  |
+| x | Zach Steindler (GitHub,TAC) | he/him | steiza |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Amanda Martin (LF) | she/her | hythloda |
+| x | Bennett Pursell (LF) |  |  |
+| x | David A. Wheeler (Linux Foundation) |  |  |
+| x | Harry Toor (LF) |  |  |
+| x | Jennifer Bly (LF, OpenSSF) |  |  |
+| x | David Edelsohn (IBM, **CTI co-lead**) |  |  |
+| x | Georg Kunz (Ericsson) | he/him |  |
+| x | Jeffrey Borek (IBM) |  |  |
+| x | Ryan Ware (Intel, **Tooling WG Lead**) | he/him | ware |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+| x | Seth Larson | he/him | sethmlarson |
+| x | Kenny Paul (LF) | he/him | KennyPaul |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  * Dr Wheeler  
+* Determine TAC quorum  
+  *  We have quorum\!  
+* Update homework/outstanding ARs- *5min*   
+  * [TAC Issue 244](https://github.com/ossf/tac/issues/244) \- Sandbox projects guidance  
+    * Mike Lieberman: I’ll put out a PR in a few hours, seems to be in a good spot.  
+      * Want some guidance for community.  
+      * Open question: Any guidance for a PROJECT (not a foundation)?  
+    * [TAC Issue 255](https://github.com/ossf/tac/issues/255) – Migrate from branch protection to rulesets  
+      * Update from Zach…. There is an “easy button” for this coming in the near future\![https://github.com/ossf/tac/issues/255\#issuecomment-1954393865](https://github.com/ossf/tac/issues/255#issuecomment-1954393865)   
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Security Tooling \- Ryan  
+    * [Feb 20 2024 Security Tooling WG \- TAC Update](https://docs.google.com/presentation/d/1kxIq8TUq8qRQNEx0ebgVp6z8FZQCuo7hdlWgQbM_rkc/edit?pli=1#slide=id.p2)  
+    * **Update on the website: [https://openssf.org/community/openssf-working-groups/](https://openssf.org/community/openssf-working-groups/)**   
+    * SBOM Everywhere SIG working on “SBOM Naming Best Practices” [https://github.com/ossf/sbom-everywhere/blob/main/reference/sbom\_naming.md](https://github.com/ossf/sbom-everywhere/blob/main/reference/sbom_naming.md)  
+    * SBOMit well received  
+    * Protobom accepted as sandbox  
+    * Bomctl on the horizon  
+    * OS Fuzzing SIG: will need to sync with them, TBD  
+    * SBOM Everywhere: drafting a landscaping proposal  
+    * Should we create a blog post on SBOM naming? We should discuss.  
+    * SBOMit: Spec version 0.1.0 published.  
+    * Protobom: Recently accepted as sandbox project. Complicated due to employment changes by Adolpho. Want to get fully integrated into OpenSSF (e.g., list on some project pages). Have a roadmap.  
+    * BOMctl: Discussion in progress.  
+    * Should Toolbelt effort be under tooling WG? Don’t know.  
+    * Next time \- let’s have a PR on “where they are” in maturity  
+    * Thanks so much for the presentation\!\!  
+  * Securing SW Repos \- Zach  
+    *  [Feb 20 2024 Securing Software Repos WG - TAC Update](https://docs.google.com/presentation/d/1t8Il4o_zXTGWk_eYoDTcLjgAFUOtTyfQ-oCwv9BzP-s/edit?usp=sharing)  
+    * **Update on the website: [https://openssf.org/community/openssf-working-groups/](https://openssf.org/community/openssf-working-groups/)**   
+    * E.g., npm, PyPI, RubyGems, etc.  
+    * Discuss what’s working & what hasn’t, a place for those conversations, then distill those lessons into guidance & tooling  
+    * Alpha-Omega has also presented, to explain their funding process  
+    * Recent work:  
+      * RSTUF: Using TUF to counter attacks. Signs package index, makes it harder to attack & determine what changed if there was a compromise  
+      * Principles for Package Repository Security (with CISA) \- created a maturity model for repositories, help determine “where’s a good place to start”  
+        * These aren’t mandates. They’re more like a menu of options, so organizations can determine what to put on their roadmaps, they can instead see what others are doing.  
+        * This also serves as a menu for funding agencies \- easy to see what a repo doesn’t do & could fund to change  
+    * Upcoming:  
+      * RSTUF: working on RubGems, starting PyPI  
+      * Principles feedback for version 0.2. In particular, what’s most important (“hair on fire”) vs. nice-to-have?  
+      * Recent package repository security capabilities (top 10 repos) \- inspire maintainers by showing what progress has been made, who’s funded work  
+    * We think we’re the first WG at graduation stage, need 1 more TAC member voting for it, please review \- [https://github.com/ossf/tac/pull/261](https://github.com/ossf/tac/pull/261)  
+    * How did that CISA engagement come about? How did it work out?  
+      * At OSS NA 2023, Jack Cable (CISA) first met Dustin (co-lead of WG), there were Zoom calls, then CISA started participating in WG & there was the OSS DC meeting  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * OSS-EU – Sept 15-18 – Vienna, Austria  
+    * CFP closes 30April  
+    * [https://sessionize.com/open-source-summit-europe-2024](https://sessionize.com/open-source-summit-europe-2024)  
+  * SOSS\*Fusion \-  Oct 22-23 ATL, GA, USA  
+    * CFP opens 21Feb  
+    * [https://events.linuxfoundation.org/soss-fusion/](https://events.linuxfoundation.org/soss-fusion/)  
+* Issues for VOTE (list issue \#)  
+  * None this week  
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * *25min* \[Requested by Sarah\] TAC/Staff interlock re 2024 alignment on community engagement, ecosystems strategy and architecture based on [Slack thread](https://openssf.slack.com/archives/C06D9AVUVD3/p1705965640081779?thread_ts=1705944053.225779&cid=C06D9AVUVD3). [crob560@gmail.com](mailto:crob560@gmail.com)also need a PR or Issue for this? I’ll create it if so. FYI [htoor@linuxfoundation.org](mailto:htoor@linuxfoundation.org)  
+    * TIs: WG, SIG, Project Cleanup \- [TAC Issue 162](https://github.com/ossf/tac/issues/162)  
+      * Zach: Great gaps identified, Marcela M. has some nice proposed actions here: [https://github.com/ossf/tac/pull/262](https://github.com/ossf/tac/pull/262)  
+      * I would suggest starting with the WGs, then recurse  
+      * Sarah: I suggest working with the WG leads to help them do it. I’d be happy to help, show up for a WG, whatever would help.  
+      * At the least, by the WG’s next presentation to TAC, present progress on completing that work  
+      * Arnaud: What’s the real goal? E.g., what’s the expected outcome, how do we get there. I’d like to do most of this offline & GitHub issues.  
+        * What does done look like? Need to make that clear  
+    * Representation of TIs on GH \+ Website  
+      * Lump in with above  
+    * Completing Roadmap from the MVSR Exercise \- [TAC Issue 258](https://github.com/ossf/tac/issues/258)  
+      * We completed the technical vision last year. We can adjust it of course, but not clear we’ll make more.  
+      * We’re good at kicking the can down the road, maybe need to set aside some time to work on this. Supply chain group does have an MVSR.  
+      * Sarah: I do have a draft. I probably need to work with the governance committee.  
+      * I think this is the referenced TAC technical vision? [https://github.com/ossf/tac/blob/main/technical-vision.md](https://github.com/ossf/tac/blob/main/technical-vision.md)  
+      * … and here is the published MVVS: [https://openssf.org/blog/2023/11/20/openssf-publishes-mission-vision-values-and-strategy/](https://openssf.org/blog/2023/11/20/openssf-publishes-mission-vision-values-and-strategy/)  
+      * Original R draft that never took flight...  [https://docs.google.com/document/d/1UoQudHQuaXNzakhOYbAS3IceI9TkSSR6N0bgm1fTTK0/edit\#heading=h.493lq0mo4y4f](https://docs.google.com/document/d/1UoQudHQuaXNzakhOYbAS3IceI9TkSSR6N0bgm1fTTK0/edit#heading=h.493lq0mo4y4f)  
+    * Mapping our TIs to the [Landscape view](https://github.com/ossf/ossf-landscape/blob/main/README.md#new-entries)  
+      * Who should do this? How can we move this forward?  
+      * Jay: Special session of diagrammer’s society?  
+      * CRob: Retired, but we could get the band back together.  
+      * There’s a *tool* but where does the data come from?  
+        * Diagramming is tough\! Mermaid doesn’t really support  
+        * Graphics dept made it prettier  
+      * CRob: Do we need to prioritize this? I’ll create an issue, but someone needs to stand up to work on this  
+        * Dana: I’m trying to characterize how things work together, I’ll take it on & see if I can create a representation  
+      * Now tracking as [TAC Issue 271](https://github.com/ossf/tac/issues/271)  
+    * SOSS CFP Participation: does TAC have a standing role?  
+      * CRob: I was part of the panel. Do we want to be involved in future efforts?  
+      * Great idea for TAC members to participate, hate to require it because TAC members are often overwhelmed  
+      * Bob C: It’d be good to have at least 1 TAC member on it. It feels odd to me if there are no TAC members in adjudication.  
+    * Plan of Actions and Milestones for top things to accomplish in 2024  
+      * Sarah Evans: Coordination with Harry on business case. Should have a call for proposals (CFPs)  
+      * Michael L: GUAC is willing to be the guinea pig.  
+    * Process for TI Funding given the set-asides in the OSSF Budget \- [TAC Issue 257](https://github.com/ossf/tac/issues/257)  
+    * Note:[https://github.com/ossf/tac/issues/257](https://github.com/ossf/tac/issues/257)  
+      * The onboarding deck is publicly viewable [https://docs.google.com/presentation/d/1yiAGkDwxTSHFsjlrx4fMdfpeb5LSW064lQZMN9n9F5M/edit\#slide=id.g254aa5f1c0a\_0\_129](https://docs.google.com/presentation/d/1yiAGkDwxTSHFsjlrx4fMdfpeb5LSW064lQZMN9n9F5M/edit#slide=id.g254aa5f1c0a_0_129)  
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+# 
+
+# **2024-02-06**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---- | :---- |
+| x | Arnaud Le Hors (IBM, TAC) | he/him | lehors |
+| X | Bob Callaway (Google, TAC)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) |  |  |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC**) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC**) |  |  |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Amanda Martin (LF) | she/her | hythloda |
+| x | David A. Wheeler (Linux Foundation) |  |  |
+| x | Jennifer Bly (LF, OpenSSF) |  |  |
+| x | Kurt Taylor (LF) |  |  |
+| x | Jeffrey Borek (IBM) |  |  |
+| x | Matt Rutkowski (IBM) |  | mrutkows |
+| x | Seth Larson | he/him | sethmlarson |
+| x | Cheuk Ho | she/ her | Cheukting |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  * Arnaud will scribe  
+* Determine TAC quorum  
+  * Zach sends regrets for today  
+  * We have quorum  
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * Supply Chain Integrity- Isaac (Mike L)  
+    * [\<link to preso\>](http://ssci.io/sci-deck) \- Questions to be posted on slack  
+  *    
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  * Still time to submit abstracts to the SOSS Community Day CFP by 9Feb – [https://events.linuxfoundation.org/soss-community-day-north-america/program/cfp/](https://events.linuxfoundation.org/soss-community-day-north-america/program/cfp/)
+
+  * Super-groovy NEW SOSS\*Fusion conference coming this fall in ATL (cfp opens \~13Feb) \- [https://events.linuxfoundation.org/soss-fusion/](https://events.linuxfoundation.org/soss-fusion/)
+
+    * Feedback on tracks wanted: [https://github.com/ossf/tac/issues/256](https://github.com/ossf/tac/issues/256)	
+
+    * Think also about submitting talks\!
+
+  * Plan is to create a Technical Steering Committee (TSC) for best practices badge project. TSC will be able to add/remove its members; plan is to also allow OpenSSF TAC to be able to add/remove TSC members. PR with details here: [https://github.com/coreinfrastructure/best-practices-badge/pull/2107](https://github.com/coreinfrastructure/best-practices-badge/pull/2107)  
+  * Kenny Paul new staff member will be doing an outreach about:  
+    * What languages are being used?  
+    * What specific skills are needed?  
+    * What should developers care?  
+* Update homework/outstanding ARs  
+  * [TAC Issue 169](https://github.com/ossf/tac/issues/169) \- Proposed Initiative: "Maintainer Experience" of OpenSSF \- *10min*  
+    * Mike: doing all “the secure stuff” for my users, including scorecard but not only, we need to make it easier and more straight forward for people to do it. How do we demonstrate the impact?  
+    * Arno: it’s been good feedback \- this is a insights into the maintainer community. I felt initially we are missing this \- and what can we do? At the end of the day \- what we are  missing is focusing on how we make their life easier… If you’re a corporate user you might do it because it’s mandated, but for regular maintainers… we need to focus on making things easier… not just asking people do more. Not easy but we need to focus on it.  
+    * Marcela: Compliance is a big incentive but may not apply to everyone. We should try to find other incentives for non corporate devs. We may not have the expertise to work on making tools simpler.  
+    * CRob: maybe we need UX experts? Are there any around?  
+    * Dan: just reviewing the issue is a good start, we need to work with the DevRel folks. How do we take a bunch of tools and tie them up into a set devs can make use of, and that makes their life easier. Keen on supporting that effort.  
+    * Sarah: good opportunity for the TAC to work with the ecosystem and community roles. We’ll have an opportunity to talk to them on the next TAC call. And the Security Toolbelt is relevant, we need to make sure we capture this persona which is critical to OpenSSF.  
+    * CRob: any help making things like scorecard easier would be welcome.  
+    * Sarah: how do we close this issue?  
+    * CRob: we can document our action plan and ask whether this satisfies the requester.  
+    * Sarah: will be happy to work on it, let’s make sure we don’t forget it but capture all the ideas here.  
+  * [TAC Issue 244](https://github.com/ossf/tac/issues/244) \- Provide guidance for projects maintained by a single organization looking to submit to OSSF Sandbox \- *5min*  
+    * Comcast has a project they were thinking of bringing to OpenSSF, they aren’t familiar with our process. Mike is trying to help, thought about developing some documentation that could provide people like that with concrete information on a path to follow to meet the criteria to start a project.  
+    * CRob: we need a PR adding the doc, once merged we can close this.  
+    * Mike: already have a doc, will put the PR. Hope to be done by the end of the month.  
+  * Updates on TAC voting-related issues: [https://github.com/ossf/tac/issues/237](https://github.com/ossf/tac/issues/237) & [https://github.com/ossf/tac/issues/235](https://github.com/ossf/tac/issues/235)  \- *5min*  
+    * Arno: No progress, aiming to get this completed by end of Q2. In the meantime anyone is welcome to comment on the issues.  
+  *  [TAC Issue 162](https://github.com/ossf/tac/issues/162)\- Foundation docs audit \-*15min*  
+    * TI ToDo \- [file PR](https://github.com/ossf/tac/pulls) to declare lifecycle stage effort is at  
+    * Sarah: some funding is available, and will be distributed based on what stage a TI is in, so that should motivate every TI to make sure they are in the stage they deserve to be in  
+    * Marcela: can we distribute this?  
+    * Arno: yes, this should be distributed, each TI lead should look into their own case and apply for their own TI. This shouldn’t take more than 30mn.  
+    * Mike: GUAC can be a guinea pig. We may need to make it clear there is a gain associated with doing this. This may just be a messaging issue.  
+    * CRob: will work with staff to make this part of the quarterly report reminder  
+* Issues for VOTE (list issue \#)  
+  * None this week  
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *     
+* Updates on older matters   
+  * Marcela: have gone through old issues, some issues were opened about starting some TI and seem to have been abandoned, I tried to ping them but got no response, do we have a timeframe after which we can just close them?  
+  * Arno: I suggest we just close them, they can always been reopened  
+  * Ryan: I suggest we define a 90 day deadline  
+  * APPROVED: if an issue regarding a new TI proposal hasn’t been followed up on after 90 days, we will close it.  
+* AOB  
+  * None this week
+
+# **2024-01-23**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---- | :---- |
+| x | Arnaud Le Hors (IBM, TAC) | he/him | lehors |
+|  | Bob Callaway (Google, TAC)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) |  |  |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, TAC) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, TAC) | she/her |  |
+| x | Zach Steindler (GitHub,TAC) | he/him | steiza |
+| x | Jennifer Bly (LF, OpenSSF) |  |  |
+| x | Amir Montazery (OSTIF, **Securing Critical Projects co-lead**) |  he/him | https://github.com/ostif-org/OSTIF |
+| x | Georg Kunz (Ericsson) |  |  |
+| x | Jeffrey Borek (IBM) |  |  |
+| x | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) |  | jeffmendoza |
+| x | Michael Scovetta (Microsoft, **Alpha-Omega, Metrics & Metadata WG co-lead**) |  | scovetta |
+| x | Ryan Ware (Intel, **Tooling WG Lead**) |  |  |
+| x | Seth Larson (PSF) | he.him | sethmlarson |
+| x | Luigi Gubello (Pitch, **Metrics and Metadata WG**) |  | luigigubello |
+| x | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+| x | Ed Baunton |  |  |
+| x | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+| x | Aeva Black |  |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  Ryan Ware  
+* Determine TAC quorum  
+  *  7 of 9 members of the TAC are in attendence  
+* Update homework/outstanding ARs  
+  *  **TAC Homework for 6Feb Call**:  
+    * [TAC Issue 169](https://github.com/ossf/tac/issues/169) \- Proposed Initiative: "Maintainer Experience" of OpenSSF   
+    * [TAC Issue 244](https://github.com/ossf/tac/issues/244) \- Provide guidance for projects maintained by a single organization looking to submit to OSSF Sandbox   
+      * Michael Lieberman \- Has a [doc](https://docs.google.com/document/d/1AsAneAtaPjevXxV1zqSWsTm93ALQ4Oy9W8z5wPy_808/edit).  Issue to better encourage the community to contribute projects to OpenSSF.  
+      * In particular, Comcast is interested in contributing something but is sole maintainer  
+      * Should look at auditing OpenSSF projects.  Probably worthwhile for us to look at this.  
+      * TAC is in conversation with staff on a couple of issues and [TAC 162](https://docs.google.com/document/d/1AsAneAtaPjevXxV1zqSWsTm93ALQ4Oy9W8z5wPy_808/edit) talks about cleaning up   
+      * Michael Scovetta \- Not clear what organizations/developers are getting if they are coming to OpenSSF.  What are they getting for what they’re giving up?  
+        * Have the gives/gets document  
+      * Arnaud \- It’s not just people that want to dump their code over to OpenSSF but also projects that don’t want to open governance and just use OpenSSF name but don’t open the broader governance  
+      * Michael Scovetta \- We need to understand that the world is full of single maintainer projects.  Should have a path for single maintainer projects.  
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * SOSS Updates \- TBD  
+    * \<[link to preso](https://docs.google.com/presentation/d/1dvS4X2BqXl8yArw5NU4_kJOid1oOzfvhlcePZ3h7BnU/edit#slide=id.p1)\>  
+    * Working Group new updates  
+      * Broken up into 2 tables; focused on action items that could potentially help industry  
+    * 4 teams  
+      * 3 focused on repository security problems  
+        * Open Source Security Integration and Enhancement Task Force  
+        * Trusted Repository Security Initiative  
+        * Open Source Integrity Standardization TF  
+      * 4th table focused on education  
+    * OSSIE-TF  
+      * Best ideas around security package repos  
+      * Hasn’t met since September  
+      * Much of the work is getting done in the Technical Initiatives  
+      * Hasn’t made progress on their objectives  
+      * Should this be separate or folded into existing WGs?  
+      * Q1 Objectives at risk.  
+      * If people are interested in carrying forward, let us know  
+    * TRSI-TF  
+      * Identical story  
+      * Straw man put together  
+      * Nothing subsequently done  
+      * TF itself didn’t meet after SOSS summit  
+      * Georg Kunz:  
+        * Slack channel created, but no progress  
+        * Important not just to have high level scoring on things but also joining with the communities  
+        * Not sure if it makes sense to continue this TF separately  
+      * Q1 Objectives at risk  
+    * OSIS-TF  
+      * Question about what hat people are wearing when participating (OSSF, other?)  
+      * Good news, a lot of things happened  
+      * Bad new, the TF hasn’t met since September.  Much of the work was done by the open source community and OpenSSF resources subsequently  
+      * Package repository security maturity model  
+      * SBOM utility requirements  
+      * Was it the TF or not?  
+      * One area we have to do better on is education  
+      * Please work with Security Tooling WG on SBOM utility requirements given the tools we have in flight  
+      * Michael Lieberman: TF objectives just dropped into communities laps: This can’t happen.  There needs to be incentives and communications.  We need to make that better.  
+    * EDU-TF  
+      * Handled a bit differently  
+      * CRob and David Wheeler were in attendance  
+      * BEST accepted 3 issues, but no member has picked the issue up  
+      * TL;DR \- Not much energy from the community.  Just CRob and DW driving is not sustainable  
+    * Is there anyone who would like to help with these?  
+      * Ian Dunbar-Hall \- Happy to help with the OSIS-TF  
+  * Metrics and Metadata \- ~~Michael~~ Luigi  
+    * \<[link to preso](https://docs.google.com/presentation/d/1vJ3Kl8Sea3ACwVmJHbP-UM5iasxUJlYr2sLvJLEZuq0/edit#slide=id.p12)\>  
+    * Working group name changed because we are focusing on Metrics and Metadata  
+      * Security-insights & Risk Dashboard  
+    * Risk Dasboard  
+      * Updating to make so end user can understand dashboard data  
+    * Security-Insights  
+      * Working on 1.1  
+      * Specification to report information about security in a machine and human processable way  
+      * No help requested from TAC  
+    * Should we consider an open hackathon to involve more people in the OpenSSF projects?  
+      * Difficult to estimate cost and resources  
+      * Not just about security engineer and community  
+    * Questions:  
+      * Comment: Michael Lieberman \- Some folks have suggested doing a hackathon around OSS and others.  Some suggestion on how to greater integrate projects.  
+  *  Securing Critical Projects- Amir \+ Jeff  
+    * [OpenSSF Securing Critical Projects WG MVSR \[Proposed\]](https://docs.google.com/document/d/1ef_qzncFf0sfQKvnc5CSeUfr1nM1N87KL4dNW7ysT5g/edit?usp=sharing)  
+    * \<[link to preso](https://docs.google.com/presentation/d/1uIXlr2vtQ-V_17tNp_WU3tLXSgkhLLsZpSZGTnk3MFY/edit#slide=id.p2)\>  
+    * As opposed to a traditional update, wanted to work on MVSR  
+    * Used the question based template and condensed it down  
+    * Requesting feedback  
+    * Connect critical projects with organizations that can provide support  
+    * Strategy for making it happen is having a set of critical projects  
+      * Need more information about the projects  
+        * What kind of project is it?  
+        * Types and kinds of help the project is looking for?  
+        * Size and funding of project  
+    * Roadmap  
+      * Cover where we’ve been and where we are  
+      * Set of projects is done  
+      * Determining metadata  
+      * Engaging projects directly  
+    * Beyond  
+      * Refresh strategy  
+      * Maybe act as intermediary?  
+    * Took all of the mission and strategy from the original readme and refined it into MVSR  
+    * Question for TAC: Need help for how the WG hosts and provides supports for projects and tools  
+    * Criticality Score infrastructure is beginning  
+    * Good time to share AWS and Eclipse Foundation audit report: Improving Security Posture with Open Source Technology Improvement Fund, Inc  
+      * Some funding came from Alpha  
+      * Example of a resource that can be done for open source projects  
+      * Adjacent Results of Critical Open Source Projects   
+        * AWS and Eclipse Foundation Funded Security Audits in 2023\. Results were aggregated and shared last week.   
+        * Impact Report: [https://ostif.org/aws-ec-audit-report-2023/](https://ostif.org/aws-ec-audit-report-2023/)	  
+        * Annual Report: [https://ostif.org/2023annualreport/](https://ostif.org/2023annualreport/)  
+        * 50th Audit Milestone: [https://ostif.org/50th-audit-milestone/](https://ostif.org/50th-audit-milestone/)	  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc)- ***10min*** **MAX**  
+  *  SOSS Community Day @ OSS-NA  
+    * 15April2024 in Seattle at OSS-NA  
+    * CFP closes 9Feb2024  
+      * [https://events.linuxfoundation.org/soss-community-day-north-america/program/cfp/](https://events.linuxfoundation.org/soss-community-day-north-america/program/cfp/)   
+  * Dev Rel update? [ossf/DevRel-community (github.com)](https://github.com/ossf/DevRel-community)  
+* Issues for VOTE (list issue \#)  
+  *  None this week  
+    *   
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * Tech Talk Project \[JBly \+ TAC\] \- *10min*  
+    * [OpenSSF Tech Talks](https://openssf.org/resources/tech-talks/) provide a dynamic platform for engaging with community members, fostering knowledge sharing, showcasing and promoting technical initiatives, and attracting leads to bolster our outreach endeavors.”  
+    * Started last year with webinar on SLSA  
+      * Over 200 people signed up  
+      * Content well received  
+    * Want to continue into 2024 to draw attention to all the things OpenSSF is doing  
+    * Feedback from TAC requested: What TechTalks should we be doing?  
+    * SLSA was great and useful  
+    * Michael Lieberman \- What should be the criteria for some of these topics.  We want to make sure there is some level of maturity.    
+    * Zach Steindler \- Similar vein \- Sequence of talks are exciting.  Is the audience people are going to be people using OpenSSF tooling?  Just open source security interest? \- Jennifer Bly \- Can open it up to anyone but leave it to TAC.  
+    * Marcela Melara \- Very software deliverable focused \- do we want that or something else?    
+    * Feels like TAC needs to do some homework \- criteria and objectives  
+    * Michael Lieberman \- To create GitHub Issue  
+    *   
+* Updates on older matters   
+  *   
+    *    
+  *   
+* AOB  
+  * None this week
+
+# **2024-01-09**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---- | :---- |
+| x | Arnaud Le Hors (IBM, TAC) | he/him | lehors |
+| x | Bob Callaway (Google, TAC)   | he/him | bobcallaway |
+| x | CRob (Intel, **BEST WG facilitator \&Vuln Disc facilitator, End User WG, TAC**) | he/him | SecurityCRob |
+| x | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+| x | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Lead, TAC**) |  |  |
+| x | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+| x | Marcela Melara (Intel, **TAC**) | she/her | marcelamelara |
+| x | Sarah Evans (Dell Technologies, **Toolbelt Co-Lead**, **TAC, GB Observer, GC**) | she/her | sevansdell |
+| x | Zach Steindler (GitHub,**TAC, Securing Repos WG Co-Lead**) | he/him | steiza |
+| x | Adrianne Marcum (LF) | she/her | afmarcum |
+| x | Amanda Martin (LF) | she/her | hythloda |
+| x | Bennett Pursell (LF) |  |  |
+| x | David A. Wheeler (Linux Foundation) |  |  |
+| x | Harry Toor (LF) |  |  |
+| x | Jennifer Bly (LF, OpenSSF) |  |  |
+| x | Angelah Liu (LF, OpenSSF) |  |  |
+| x | Dana Wang (LF) |  |  |
+| x | David Edelsohn (IBM, **CTI co-lead**) |  |  |
+| x | Georg Kunz (Ericsson) |  |  |
+| x | Jeffrey Borek (IBM) |  |  |
+| x | Michael Scovetta (Microsoft, **Alpha-Omega, ID Security Threat WG lead**) |  |  |
+| x | Ryan Ware (Intel, **Tooling WG Lead**) |  |  |
+| x | Justin Cappos (NYU, **SCIR**) | he/him | JustinCappos |
+| x | Kris Borchers (GM Financial) | he/him | kborchers |
+| x | Aeva Black (CISA) | they/them | AevaOnline |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *  David W  
+* Determine TAC quorum  
+  *  We have quorum with 9 out of 9 members attending  
+* Update homework/outstanding ARs  
+  * Welcome the new TAC, do intros  
+    * Group voted for CRob to continue on as chair and Arnaud to be Vice-Chair  
+    * Dan Appelquist: Was at Synk, now at Samsung. Also do W3C.  
+    * Arnaud: IBM. Plan to continue improving our governance structure and process to make it easier for people to find their way into OpenSSF.  
+    * Marcela Melara: Research scientist at Intel Labs. Want to make connection between sectors, groups, etc.  
+    * Jay White: Microsoft. You see me in many meetings\! Happy to now be on the TAC. Have been at Microsoft for 2 years. Yes, that’s a “Spy vs. Spy” background.  
+    * Zach Steindler: Esp. interested in securing repositories like npm, PyPI, Nuget, Rubygem, Rust crates, etc.  
+    * Sarah Evans: Dell. Work in the office of the CTO doing cybersecurity R\&D. Involved in OpenSSF for 2 years. “I’m a security person at heart.” Want to accelerate security, go fast. Want to work on processes to help speed results.  
+    * Mike Lieberman: Do a lot with CNCF, finance sector. GUAC, involved in SLSA. Also a GB member as well. Co-founded a startup, there’s a lot of opportunity here for a startup\!  
+    * Bob Callaway: (via phone). Google. Third tour on the TAC. Work on Sigstore. Manage Google side of SLSA, GUAC, etc.  
+    * CRob: Upstream security for about 10 years.  
+* TAC Update on Groups \- *10 min* MAX each (provide template ahead as pre-read)  
+  * AI / ML WG, Mihai Maruseac and Jay White; Jay presenting,   
+    * \<[link to preso](https://docs.google.com/presentation/d/1kkP9rK-LnqRgUHJ2_16iAJcGb4qKmH9GT3mCUwLXiH8/edit?usp=sharing)\>  
+    * WG formed, in incubating phase.  
+    * David A. Wheeler gave updated presentation on current state of AI/ML security  
+      * Intend to build on that presentation  
+    * Reaching out to related groups, esp. LF Data.  
+    * Can we refine the goal of the WG? AI, OSS, security. Is there a niche for this group that’s not happening elsewhere?  
+      * It’s still evolving. We do believe there’s a niche.  
+      * Everyone has great ideas, but there’s so much to do, so people are generally happy to divide up the work.  
+      * Other TAC members especially want to make sure there’s a strong connection to LF AI & Data.  
+      * Jay: Yes, the cross-pollination is happening.  
+    * AI/WG leaders: Please create a PR to add the AI WG to  [https://github.com/ossf/tac\#working-groups](https://github.com/ossf/tac#working-groups)  
+  * SOSS Updates   \<group\>\<lead/co-lead\>   
+    * ~~\<link to preso\>~~  
+    * ***SOSS UPDATES WILL BE DISCUSSED AT THE 23JAN TAC MEETING***  
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc)  
+  * Welcome to Angelah Liu to the LF Staff who will be helping with marketing and communications.  
+    * New to the community, passionate to learn\!  
+  * OSS-NA CFP \- [https://events.linuxfoundation.org/open-source-summit-north-america/program/cfp/](https://events.linuxfoundation.org/open-source-summit-north-america/program/cfp/)   
+    * CFP Closes: Sunday, January 14, 2024 at 11:59 PM PST (UTC \-8)  
+  * SOSS Community Day North America (formerly called OpenSSF Days) CFP to open on 1/11/24  
+  * Planning has started for a tabletop exercise at OSS-NA for incident response & improve overall security posture \- would like TAC involved in the planning process [TAC Issue 239](https://github.com/ossf/tac/issues/239) \- Dana \- *5min*  
+    * Plan to work with public sector, am talking with Aeva  
+    * Use/expand tools using, perhaps\!  
+    * Can we generate guidance for others & ourselves for running a tabletop exercise? In particular, how do we follow-up to turn ideas into action & create partnerships.  
+    * Dana: Currently plan to work with existing WGs instead of creating another one.  
+    * CRob: I suggest starting with the Vulnerability Disclosures WG, I think it’d fall in that well.  
+    * Dana: I think we were focused more on producer than consumer, that’s why we didn’t include S2C2F.  
+    * Sarah: What’s the motivation? When talking with people with different backgrounds. Even large companies don’t run tabletop exercises, and as a result they can’t do things quickly. E.g., log4j response was really slow response & painful, companies weren’t ready. Want to prepare organizations for an incident. Also want OSS projects to be more prepared.  
+    * Perhaps we should also integrate S2C2F, since you are including consumers in the table top with producers. Need to think about that.  
+    * Will have a panel of 20 people.  
+* Issues for VOTE (list issue \#; for each proposal, flag any issues for voting for next meeting)  
+  * [TAC PR 238](https://github.com/ossf/tac/pull/238) \- protobom \- OpenSSF Sandbox Application \- Puerco \+ Ryan Ware \- *15min*  
+    * Adolfo: Don’t have a visual presentation, no longer at former org.  
+    * US Dept of Homeland Security (DHS) invited organizations to collaborate on some tools. Chainguard & some others responded. One was an SBOM translator (between SBOM formats) & other was software ID translator (package URLs to CPEs, etc.). We started working on first one, did some tests. Proposed a new project. See video for explanation.  
+    * Protobom is a result \- it defines a set of protocol buffers that abstract the SBOM data. Written in Go, there’s also a Python library. Make it easy to read/write SBOM data for exchange (not for persistence, though that’s possible). SPDX & CycloneDX supported.  
+    * Already in use for a few projects, e.g., OpenVEX for reading SBOMs to get VEX. Currently working on Kubernetes to use it.  
+    * Had recent 0.3 release.  
+    * Need to go through Sandbox application criteria:  [https://github.com/ossf/tac/pull/238\#issuecomment-1877212030](https://github.com/ossf/tac/pull/238#issuecomment-1877212030)  
+    * Mike L: One concern \- often data fails to fully validate. E.g., there’s a string, but it doesn’t match the required regex of a spec.  
+      * Adolfo: We need to look at this in layers. Originally we created our own types to serialize/deserialize, but that didn’t work well. We now use native libraries. So if they have parsing limitations, we need to fix those libraries.  
+      * Going one layer up, if it could be read by the library, we can add validations.  
+    * Call for vote (TAC members only\!), per [https://github.com/ossf/tac/pull/238\#issuecomment-1877212030](https://github.com/ossf/tac/pull/238#issuecomment-1877212030)  
+      * 1.) TI must be aligned with the OpenSSF mission and either be a novel approach for existing areas or address an unfulfilled need. It is expected that the initial code needed for an OpenSSF WG to work be kept within their repository and will not function as a project in its own right. Should initial WG code grow and mature that it warrants its own Project status, then it is subject to Sandbox entry requirements. It is preferred that extensions of existing OpenSSF projects collaborate with the existing project rather than seek a new project. \- CRob thinks so, no objections.  
+      * 2.) TI must maintain a diversified contributor base (i.e. not a single-vendor project). TI must have a minimum of two maintainers with different organization affiliations. \- Diverse org: 6 organizations contributing, very diverse  
+      * 3.) TI must find an aligned WG to host the TI and must have a TAC sponsor that can help guide the TI through processes. \- Host: Tooling WG  
+      * 4.) TI agrees to follow the [Secure Software Development Guiding Principles](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/SecureSoftwareGuidingPrinciples.md) and the [Open Source Consumption Manifesto](https://github.com/ossf/wg-endusers/tree/main/MANIFESTO). \- no problems  
+      * 5.) If contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF). \- All okay  
+      * 6.) Provides quarterly updates to the TAC on technical vision and progress on vision. \- will do  
+      * 7.) TI will have a [SECURITY.md](https://github.com/ossf/project-template/blob/main/SECURITY.md) that describes how the Project manages vulnerabilities, or more broadly how the OSSF handles vulnerability reports \- Missing, but can add it today  
+      * VOTE: Unanimous, 9/9 agreed. WELCOME protobom to the Tooling WG\!  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  * [TAC Issue 232](https://github.com/ossf/tac/issues/232) \- \[Proposal\] LFX Mentorships for OpenSSF Projects \- *5min*  
+    * Note: 2024 Term 1 for LFX Mentorship: [https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2024/01-Mar-May](https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2024/01-Mar-May)  
+      * project proposals due: Jan 24, 2024  
+      * mentee applications open: Jan 29 \- Feb 13, 2024  
+      * application review/admission decisions/HR paperwork: Feb 14 \- 27  
+    * Zach will send email on TAC, the deadline is Jan 24\!  
+  * These two issues will be homework and not discussed in the call this week (time-depending)  
+    * [TAC Issue 235](https://github.com/ossf/tac/issues/235) \- Clarify Community Voter Eligibility documentation and requirements and submit suggestions to the Governance Committee  
+    * [TAC Issue 237](https://github.com/ossf/tac/issues/237) \- Make TAC voting process simpler and clearer \- Arnaud to work on.  
+* Updates on older matters   
+  *   
+* AOB  
+  * Justin Cappos: (quick question / query about GB helping TAC)  
+* 
+
+# **\<Agenda Template\>**
+
+# Attendance (please **mark an “X” if you are here,** or add-row name/email/affiliation if joining)
+
+|  | Name/Affiliation | Pronouns | GH ID |
+| ----- | :---- | :---: | :---- |
+|   | Arnaud Le Hors (IBM, **TAC**) | he/him | lehors |
+|   | Bob Callaway (Google, **Sigstore, A-O**, **TAC**)   | he/him | bobcallaway |
+|   | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+|   | Jay White (Microsoft, **AI/ML WG Lead, DEI WG Co-Lead, TAC**) | he/him | camaleon2016 |
+|   | Marcela Melara (Intel, **DEI WG Co-lead**, **TAC**) | she/her | marcelamelara |
+|   | Michael Lieberman **(**Kusari**, TAC)** | he/him | mlieberman85 |
+|   | Sarah Evans (Dell Technologies, **GC,** **TAC**) | she/her | sevansdell |
+|   | Zach Steindler (GitHub,**TAC Chair**) | he/him | steiza |
+|   | David Edelsohn (IBM / **CTI AI Alliance**) | he/him | edelsohn |
+|   | Henri Yandell **(**AWS **/ Alpha-Omega)** | he/him | hyandell |
+|   | Jeff Mendoza (Kusari, **Securing Critical Projects co-lead**) | he/him | jeffmendoza |
+|   | Michael Scovetta (Microsoft, **Alpha-Omega**) | he/him | scovetta |
+|   | Mihai Maruseac (Google, **AI/ML WG co-lead**) | he/him | mihaimaruseac |
+|   | Ryan Ware (**Tooling WG Lead**) | he/him | ware |
+|   | Yesenia Yser (**DEI WG Co-Lead**) | she/her | Cyber-JiuJiteira |
+|  | Daniel Appelquist (Samsung, **TAC**) | he/him | torgo |
+|  | Adrianne Marcum (LF) | she/her | afmarcum |
+|  | Angelah Liu (LF) | she/her |  |
+|  | Christian “Fukami” Horchert | he/him |  |
+|  | CRob (LF) | he/him | SecurityCrob |
+|  | David A. Wheeler (LF) | he/him | david-a-wheeler |
+|  | Jeff Diecks (LF) | he/him | GeauxJD |
+|  | Khahil White (LF) | he/him | theheels |
+|  | Kris Borchers (LF) | he/him | kborchers |
+|  | Naomi Washington (LF) | she/her | Naomi-Wash |
+|  | Ram Iyengar (LF) | he/him | ramiyengar |
+|  | Reden Martinez (LF) | he/him | redenmartinez |
+|  | Riaan Kleinhans (LF) | he/him | riaankleinhans |
+|  | Sally Cooper (LF) | she/her |  |
+|  | Todd Moore (LF) | he/him |  |
+|  |  |  |  |
+|  | Adolfo Gracia Veytia (Stacklok) | he/him | puerco |
+|  | Aeva Black (CISA) | they/them | AevaOnline |
+|  | Chris de Almeida (IBM) | he/him | ctcpip |
+|  | Cristian Urlea (University of Glasgow) | he/him | cristianurlea |
+|  | Ed Thomson (Stacklok) | he/him | ethomson |
+|  | Eddie Knight (Sonatype, Inc.) | he/him | eddie-knight |
+|  | Eddie Zaneski (Defense Unicorns) | he/him | eddiezane |
+|  | Evan Anderson (Stacklok) | he/him | evakanderson |
+|  | Georg Kunz(Ericsson) | he/him | gkunz |
+|  | Ian Dunbar-Hall (Lockheed Martin) | he/him | idunbarh |
+|  | Jacques Chester (independent) | he/him | jchester |
+|  | Jeffrey Borek (IBM) | he/him | jtborek206 |
+|  | Juan Antonio Osorio (Stacklok) | he/him | JAORMX |
+|  | Louis Lang (Phylum, Inc.) | he/him | louislang |
+|  | Luke Hinds (Stacklok) | he/him | lukehinds |
+|  | Madison Oliver (GitHub) | she/her | Taladrane |
+|  | Neal McBurnett (Independent) | he/him | nealmcb |
+|  | Seth Larson (Python Software Foundation) | he/him | sethlarson |
+|  | Stacey Potter (Stacklok) | she/her | staceypotter |
+|  | Xavier Rene-Corail (GitHub) | he/him | xcorail |
+|  |  |  |  |
+
+### Agenda:
+
+*Agenda Items should be entered no less than 24 hours prior to call.  New business should be logged as an [Issue](https://github.com/ossf/tac/issues) in the TAC repository.*
+
+* Request volunteer for scribe  
+  *    
+* Determine TAC quorum  
+  *    
+* Update homework/outstanding ARs  
+  *   
+* TAC Update on Groups \- *10 min* **MAX** each (provide template ahead as pre-read)  
+  * WG \- Leader  
+    * \<link to preso\>  
+  *    
+* Any Foundation/Staff Updates to provide (news, events, blogs, etc) \- *10min* **MAX**  
+  *    
+* Issues for VOTE (list issue \#)  
+  *    
+    *   
+  * Please flag any issues for voting for next meeting  
+* Review new work \- (seeking TAC comments, edits, approvals) \- ISSUES & PRs filed in TAC Repo  
+  *     
+* Updates on older matters   
+  *   
+* AOB  
+  * None this week
+
+[image1]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAWCAYAAAArdgcFAAABw0lEQVR4XpVUPUsDQRBNtFEUotnb3aApAv6JNCJaaG1qi1T+Af0PtnaxDP4C9ReIIKSzsFBQEFIpErVJNFWcl0zi7HinmwfD3r15793cx14uF4EkSTasNcfOmSesONeaqWCtXXcu6XpvB7T+Kua70GlvJmi6WlZgVo30pqazApDoSBunKfh15hC4shA+U3X+uwPud1jPvNnV2Zh6YpA8cS3iLmg9pNqnOrA2wXlL6rL8CDiX0wTNSKi7PJONTxU+82OLwowMR15WoytdsYDv14Demy1xO4NSKdnUxhjAJ3OQi+d9KslyuTyvjTGAT+Y4Z5u0E827JJcI2hiDQqGwLHMo9w3bvB5eMeU7jYDaJwiv46e0EoYnH9oYA/hkDnKHDfWNohqVSmVO+VMBHelPpD/YK0T0uPGCBtcltfITUTry9OKuUobrTRTeF6sj0t4aY1blBKPyCyIQ72lx3FOh7CtWpR6Pps0XaNLL2aP1msU3gZBB/KsO5YHaWjvEeBqarMTULKYMRAz6ed2lBP/9X/Le9cdCWnH8qDUA8fdhsOtrTSpI3KDwLzY+6D4AnoeArqH7/8I5t+ZccVvzAPE76Gte4hvunQZfeh955AAAAABJRU5ErkJggg==>
+
+[image2]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAUCAYAAACXtf2DAAADzElEQVR4XoVV+28UVRTef8v4i4oUrLykidYaMU2sqcTys4kaoyZqAlJbtywFotBVaEPSpD5AGwk+orVaC8GNQYN90LRZLO3OzD33MbPb/TznDpNut4tM8u3cufc87vnOd+/mZucVZudCj2vzERb+1TDGIFCGvwnLdxWs0dBa+/fKGuH6okYQGW+3eIcQKu1910MDZw1uLGksrUocjdzxSYW+CxpHRjWeOkFo6zcoLRvszWv0FHmuoDH2a8QJCJ9Np98vjhD2DRFKS4Sj3ygcKBi8coGw5yONw+cJPeci7B/SmCwp5CSLJoXf50PsHLQoVzR2fGhRIet3Yzhw26BBJYzQzk5xbJHEDmvKsp1B/rsII1OBt7vGlT1/llBNHAz7PtZvkSMi3FyJsKtg8edyhHqVHfMW9ZqDtdZT0zNGmL4V4KVR4qSWk8Rs57xd/vsAX92oeLuFVYPei3RvPY2TW1lT2HPGYXZRoeqMX9j/scXsbUItNrgTcAUnLa8Rdg1b5jmdn5qL0DFiMfhDhC9LIWSj0r/eceKNGWwkBo+zX+6tb5m7Txy6uAfPjhp0MubKETq5L11jBgeLBjOL3Dxn8dM/Ch1Fy/MMtitXFPp/1PhlgXzDy+sKL08Yn6zqNHaestIDC+VikIDHQcSqYL7DKGTIbpjzJOEEztOjIlZLECLidaHFWIdqtertJHAlCNg/rcgwVTlZEM4EGecRBxGIUcwNVbaKz/9OMPibw9CMw9X5xAcVW0ksG2j2lbHEzElpjfC7ujeu1zjotEXf1yzDS8a/+y6n4yM8nrgpm9I+eLOvPzc8n2vesUzKruobCV7lIL0T/4/TXJVSW30FGWWeIikx41kmtQpxeNyge0zj0Pnt6GZBZGvyLvyc9kd8hf+sBxKzJUVxnKDzrMZz5zRqdWxDcSbGC58yHQm8naDG50J8G3Ffiv4qx3jmjMbTpzVaPbdWa9iop+ODwxodp7Q/9c2CUUqlJzlgaQlkQmi6ftuh42R677R6JEH27MsTDvAdlilK1CWQsVC1pYKsrLUoxt4BQns/NYTdfBbu1lCccn78xHHC7g/kYKXVb6tAeJePDJKkJsf8fcKT7NjNVA1M2i14c9yi/RihiyvcfTR9xy71FUa8ULIeyE9jWV4JfFIvThu0vUcPxI53CSvrm7JsVJHEbClTMTAU4VCB8Og798cjbxOGrxhW0OZV0VKmGT2ZTFPwNWEJA5c1HnqN8PAbTXidcOWP9BLc7vsAmWaNEieZ22CNXy1ZHPuC+3FJ89+r4QPh/Lo0spVv1uT/AMVKsrOxVTdeAAAAAElFTkSuQmCC>
+
+[image3]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAUCAYAAACaq43EAAACLElEQVR4Xr3Vy27TQBQG4GHDogsegBdI4jpjz9i5t01S7qI8AAvWgFjAI7CDVwDxBGVD4yZpSOqI3HAa3KBGSblUCAERQhQJUYQQRD0ct41F60Z1FvVIn+LMOeP/xFmYkL1lRCKnuinlUSep9NDXtaTyGz9hPRWC1+kQvJ21hGFjBKv2BvteoW5KhU5KGeD5H+gDqnaS6rVhlr3aM/xWD5tfzvBj1U2qYIfi1Yl1DG1Pc4+w2k6wmeB3zCkGqx7pDX91K8E7LxIMvNKe4qBdUSZIMy5vrcRlcCUmwUqUOvfH0EJGhAmkFWdgxGRXzMtn4Gf/ExjpKBg4wMG6W80YnyOrOEEjKrnSujQLw9U3TXg+reI+dfQdpR6lN4mJwbWI5ErzYtoOttafwQDe6TrUYwzr1NE/Sj0s3Sct/N8qYeqKcWF/8HB929yEjXwOanHuOHOYaoQ+JE2c4Fko6Erj/OHBHx/PQ5n5Hf2jVEIY3MAJyqroSu1cal9gX9NgWfY5+o6C4fdINURhWRFdqZzdDf5cKkFJDjjqY7hBdC5CkU+6oifCUGSCY39cBS7OkQITtwoMv3jkKcqxSYHkmbCWlwXwivXEHiinJ0hWFm9nJQG8ouOjtl+LRZxkkQa8UrHfyRnJf30Jp9GwcJxyNLBthw7XvCCc1KhwNxP0GwtB3xf0a0H0bWtBP2R3D0EeLVmkA/ZqVs9iMAB4D8Czf9H3J9T3Hu9RzlD/1f/z/gGLlffpLfkfIgAAAABJRU5ErkJggg==>


### PR DESCRIPTION
- minutes: Add 2024 archive
- README: Update meeting notes link to 2025 version

cc: @ossf/tac 