### PR TITLE
CHANGELOG: Add entry for TAC onboarding document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # OpenSSF TAC Changelog
 
+* 2025-01-08: Add initial onboarding document for incoming TAC members [#429](https://github.com/ossf/tac/pull/429)
 * 2024-12-11: Added global cyber policy to sandbox working groups
 * 2024-11-07: Add security baseline reqs to project lifecycle templates
 * 2024-10-22: Add TAC decision type for TI quarterly updates [#402](https://github.com/ossf/tac/pull/402)


### PR DESCRIPTION
Follow-up to @lehors' comment in https://github.com/ossf/tac/pull/429#issuecomment-2578510533:

> I'm not sure we should keep maintaining that file but as things stand I should point out that this should have included a new entry into CHANGELOG.md
