### PR TITLE
Update funding process with 2025 schedule

### DIFF
--- a/process/TI Funding Request Process.md
+++ b/process/TI Funding Request Process.md
@@ -1,53 +1,69 @@
-This process details how an eligible OpenSSF Technical Initiative can petition for resources and funding.
+This process details how an eligible OpenSSF Technical Initiative (TI) can apply for funding.
 
-## Pre-conditions ##
-    - The TI must have an identified lifecycle phase inside the OpenSSF, such as sandbox, incubating, or graduated. 
-    - The TI requesters should know: 
-          - Within general funding limits for the TIs at the respective lifecycle, that are to be determined. 
+> [!IMPORTAT]
+> Please review the "Qualifying for funding" section carefully
 
-## Workflow ##  
-  1. TI or TIs working together see a need for funding some work that doesn’t exist within an existing give/get that is pre-approved. For example cloud credits to do a PoC or case study.
-  2. TI(s) get consensus on the scope of how much money they are asking for and to be spent on what. For example $10k-$15k in cloud credits over a year to spend on building out a PoC to test out <some set of things>
-  3. TI(s) drafts that includes:
-     - Problem Statement in the form below
-     - Proposed work and other work considered
-     - Benefit to OpenSSF and ecosystem
-     - Approximate cost
-     - If a third party (like a cloud provider) is requested, please list any vendor preferences (Note, these are not guaranteed and if the request is approved, you will work with OpenSSF Staff to finalize vendors to reach alignment where possible).
-  4. TI submits this issue to the TAC. This will be treated like a CFP. Respondents will be notified in writing, and approved proposals will be published.
-  5.  Submitted funding requests will be reviewed at least quarterly, relative to each other. Dates where proposals can be accepted, as well as when the review cycle will occur, and when decisions will be made. The TAC reserves a weeklong window for technical merit, and the finance review will occur the following week.
-  6.  TAC evaluates the technical merit of the proposal and checks that its goals within OpenSSF and ecosystem seem reasonable and achievable. (See TAC evaluation below). During the two week review period, TAC and OpenSSF Staff may iterate with TI(s) on the proposal with any questions needed to make the technical merit and funding approval decision.
-  7. TAC brings approved proposals to the funding workflow (see below).
-  8. The OpenSSF General Manager or delegate will review any proposals with TAC technical merit (see Finance evaluation below) and determine which proposals will be funded based on the availability of funds. Funding beyond the delegated authority of the OpenSSF General Manager or Delegate will request the approval of the Budget and Finance Committee, and/or Governing Board. OpenSSF Staff will distribute funds. 
-  9. TAC/OpenSSF General Manager or delegate will review funding initiative status on milestones. If a funding initiative has more than one milestone, funds may be dispersed after each milestone is achieved (funding initiatives asking for more funds should most likely have more milestones for fund releasing). If the milestone is reached, the TAC/OpenSSF General Manager or delegate agree that Staff should disperse funds for additional milestones(s).
+## Qualifying for funding
 
-## TAC Review ##
-  - Is this request in line with the [TAC Technical Vision](https://github.com/ossf/tac/blob/main/technical-vision.md)?
-  - Is this request in line with the OpenSSF [MVS](https://openssf.org/about/), and soon to be [finalized R](https://docs.google.com/document/d/1UoQudHQuaXNzakhOYbAS3IceI9TkSSR6N0bgm1fTTK0/edit#heading=h.493lq0mo4y4f)? (this is how GB/GC communicate “top-down” initiatives, like the SOSS Task Force).
-  - Does the requester(s) have an accepted [TI lifecycle phase](https://github.com/ossf/tac/tree/main/process) in good standing?
-      - Within general funding limits for the TIs at the respective lifecycle (e.g. Sandbox should generally ask for less than Incubating, which should ask for less than Graduated)
-      - Within approved categories of asks (e.g. no asking for a TI outing at a fancy restaurant but yes to cloud credits)
-      - What will be the milestone review requested and when?
+- This process is for existing OpenSSF TIs that have a [documented lifecycle phase](/process/Technical_Initiative_Lifecycle.md) (e.g. sandbox, incubating, or graduated)
+  - If you are not an OpenSSF TI, you can make use of other funding source like [Alpha-Omega](https://alpha-omega.dev/grants/how-to-apply/)
+- Depending on the lifecycle phase of your TI, you may already qualify for things like a logo, stickers, or other swag; see [TI Gives and Gets](/process/TI-Gives%2BGets.md)
+  - Contact OpenSSF staff about items in [TI Gives and Gets](/process/TI-Gives%2BGets.md); you do not need to follow this process
+
+## Process to apply for funding
+
+  1. Review "Qualifying for funding" section above.
+  2. Applying TI should [fill out funding application](https://github.com/ossf/tac/issues/new?template=funding_application.yml)
+  3. TAC will review funding applications with the criteria listed in "TAC review" section below according to the schedule listed in the "Review cycles" section below
+  4. TAC notifies the OpenSSF General Manager (or delegate) to determine which proposals will be funded based on the availability of funds. Funding beyond the delegated authority of the OpenSSF General Manager will need approval of the Budget and Finance Committee, and/or Governing Board. OpenSSF Staff will distribute funds.
+  5. TAC, OpenSSF General Manager, or delegate will review funding initiative status on milestones. If a funding initiative has more than one milestone, funds may be dispersed after each milestone is achieved (funding initiatives asking for more funds should most likely have more milestones for fund releasing). If the milestone is reached, the TAC, OpenSSF General Manager, or delegate agree that Staff should disperse funds for additional milestones(s).
+
+## Example funding requests
+
+> [!IMPORTAT]
+> These examples may use previous processes; please review the "Process to apply for funding" section above for the current process
+
+Here are some example funding requests that were approved, and we'd like to see more of in the future:
+
+| TI | Lifecycle Stage (at the time) | Link | Amount | Notes |
+| --- | --- | --- | --- | --- |
+| DEI WG | Incubating | [Outreachy intern for GUAC](https://github.com/ossf/tac/issues/265) | $8,000 | |
+| RSTUF Project | Sandbox | [Cloud/k8s deployment costs for tests, demo and validations](https://github.com/ossf/tac/issues/315) | €1,000 | These cloud credits were specifically to pay for development costs; the OpenSSF governing board does not want to pay for ongoing hosting costs of services |
+| Sigstore Project | Graduated | [Documentation Modernization](https://github.com/ossf/tac/issues/339) | $50,000 | |
+| RSTUF Project | Incubation | [Security Audit for 1.0.0](https://github.com/ossf/tac/issues/379) | $44,000 | |
+| Securing Repositories WG | Graduated | [Technical Writer for Package Yanking Guidance](https://github.com/ossf/tac/issues/414) | $4,000 | |
+
+## TAC review
+  - Is this request in line with the [TAC Technical Vision](/technical-vision.md)?
+  - Is this request in line with the OpenSSF [Mission, Vision, Values, and Strategy](https://openssf.org/about/)?
+  - Does the requester(s) have an accepted [TI lifecycle phase](/process) in good standing?
+      - Does the requested amount align with the lifecycle stage the TI is at?
    - Final decision is open discussion and a majority consensus vote.
    - TAC moves approved requests forward and recommends to the OpenSSF General Manager and the Governance Committee for dispensation.
 
-## Review Cycles
+## Review cycles
 
-### Q2 2024
-   - Request submission deadline: June 7, 2024
-   - TAC review period: June 10-14, 2024
-   - Decisions announced (in writing): No later than June 21, 2024
-   - Accepted requests published: June 26, 2024
+### Cycle 1
+ - Request submission deadline: Friday, February 14, 2025
+ - TAC review period: Friday, February 14 - Friday, February 28, 2025
+ - TAC recommendation announced: No later than February 28, 2025
 
-### Q3 2024
-   - Request submission deadline: Sep. 06, 2024
-   - TAC review period: Sep. 09 - 13, 2024
-   - Decisions announced (in writing): No later than Sep. 20, 2024
-   - Accepted requests published: Sep. 25, 2024
+### Cycle 2
+ - Request submission deadline: Friday, April 18, 2025
+ - TAC review period: April 18 - May 2nd, 2025
+ - TAC recommendation announced: No later than May 2nd, 2025
 
+### Cycle 3
+ - Request submission deadline: Friday, June 20, 2025
+ - TAC review period: Friday, June 20 - Thursday (sic), July 3, 2025
+ - TAC recommendation announced: No later than July 3, 2025
 
-### Q4 2024 (for Q1 2025)
-   - Request submission deadline: Nov. 29, 2024
-   - TAC review period: Dec. 02 - 06, 2024
-   - Decisions announced (in writing): No later than Dec. 13, 2024
-   - Accepted requests published: Dec. 18, 2024
+### Cycle 4
+ - Request submission deadline: Friday, August 15, 2025
+ - TAC review period: Friday, August 15 - Friday, August 29, 2025
+ - TAC recommendation announced: No later than August 29, 2025
+
+### Cycle 5
+ - Request submission deadline: Friday, October 17, 2025
+ - TAC review period: Friday, October 17 - Friday, October 31, 2025
+ - TAC recommendation announced: No later than October 31, 2025


### PR DESCRIPTION
For #419 

There wasn't consensus on rolling evaluation vs batching, so I decided on batching every 2 months instead of every 3 months. This gives us 5 review periods (without trying to squeeze one in at the end of the year). Review periods by the TAC are two weeks long, in case some TAC members are on vacation or otherwise temporarily unavailable to vote.

This change also streamline workflow / review process and addd examples of successful funding requests.

It does not change the funding process from using issues to using pull requests, although I'm still considering that for a follow-up change. For the upcoming review cycle we already have at least 1 issue to include in our review anyways, namely https://github.com/ossf/tac/issues/424.