### PR TITLE
Readme wg updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 
 ### Working Groups (WGs)
 
-| Name                         | Repository                                              | Notes                                                                                                  | Status     |
-| ---------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------- |
-| AI/ML Security                 | https://github.com/ossf/ai-ml-security                  | [Meeting Notes](https://docs.google.com/document/d/1YNP-XJ9jpTjM6ekKOBgHH8-avAws2DVKeCpn858siiQ/edit)  | [Incubating](process/wg-lifecycle-documents/ai_ml_incubating_stage.md) |
-| Diversity, Equity, & Inclusion | https://github.com/ossf/wg-dei                          | [Meeting Notes](https://docs.google.com/document/d/1zGTOJdFVIMnixT3EFQ6_bbQ0iy7f4Z4TxhX9A5VY9TM/edit)  | Incubating |
-| Global Cyber Policy            | https://github.com/ossf/wg-globalcyberpolicy            | [Meeting Notes](https://drive.google.com/drive/folders/1FfWXtQTQe1XAOX0R_QaNamyGgKGLRaKW)              | [Sandbox](process/wg-lifecycle-documents/Global_Cyber_Policy_WG_sandbox_stage.md) |
-| Securing Critical Projects     | https://github.com/ossf/wg-securing-critical-projects   | [Meeting Notes](https://docs.google.com/document/d/1j_efLVDXGoKgfHHZbJtpBxd_Gso1ghHBdK3NfEVc15o/edit)  | [Incubating](process/wg-lifecycle-documents/securing_critical_projects_incubating_stage.md) |
-| Securing Software Repositories | https://github.com/ossf/wg-securing-software-repos      | [Meeting Notes](https://docs.google.com/document/d/1HzA4M4toiExUYQAkuLqimy4EuuunHagUQ7rZKJDb1Os/edit)  | [Graduated](process/wg-lifecycle-documents/securing_software_repositories_graduation_stage.md) |
-| Security Best Practices        | https://github.com/ossf/wg-best-practices-os-developers | [Meeting Notes](https://docs.google.com/document/d/1JY8FREBPCUUFpuv7-4B9EjeS2MLDpel0dbG5DFWrTns/edit)  | [Graduated](process/wg-lifecycle-documents/BEST_practices_wg_graduation_stage.md)  |
-| Security Tooling               | https://github.com/ossf/wg-security-tooling             | [Meeting Notes](https://docs.google.com/document/d/1bFpHEbbEUf2rWiYXQY7cGg1HrmI9TqwaD8U_3Hi9A8I/edit) | Incubating |
-| Supply Chain Integrity         | https://github.com/ossf/wg-supply-chain-integrity       | [Meeting Notes](https://docs.google.com/document/d/1moVFPn5pLi-uGs840_YBCrwdpHajU0ptFmlL4F9GryQ/edit)  | Incubating |
-| Vulnerability Disclosures      | https://github.com/ossf/wg-vulnerability-disclosures    | [Meeting Notes](https://docs.google.com/document/d/1AXkapzjZ-SxwcBN7rZeSstkzdapd3sbzfHDxz6A59Ic/edit)     | [Graduated](process/wg-lifecycle-documents/Vuln_Disc_wg_graduation_stage.md) |
+| Name                           | Repository                           | Notes              | Staff Contact    | Status     |
+| ------------------------------ | ------------------------------------ | ------------------ | ---------------- | ---------- |
+| AI/ML Security                 | [GitHub](https://github.com/ossf/ai-ml-security) | [Meeting Notes](https://docs.google.com/document/d/1X7lCvAHY0x7HMaCQx-7KKPjSBPQ6v02TynQpOPXnXFI/edit) | Jeff Diecks | [Incubating](process/wg-lifecycle-documents/ai_ml_incubating_stage.md) |
+| Diversity, Equity, & Inclusion | [GitHub](https://github.com/ossf/wg-dei)         | [Meeting Notes](https://docs.google.com/document/d/17j8uN_radgNcY4G8u1Ua8FN__lUL4TeUN0gb-D2TrZ4/edit)  | Khahil White | Incubating |
+| Global Cyber Policy            | [GitHub](https://github.com/ossf/wg-globalcyberpolicy) | [Meeting Notes](https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit) | Jeff Diecks & Kris Borchers | [Sandbox](process/wg-lifecycle-documents/Global_Cyber_Policy_WG_sandbox_stage.md) |
+| Securing Critical Projects     | [GitHub](https://github.com/ossf/wg-securing-critical-projects) | [Meeting Notes](https://docs.google.com/document/d/1YkxOFs9x9YCtUfYeOG7Gy3OBX0cTDbZTEgOdvmEo6FE/edit) | Kris Borchers | [Incubating](process/wg-lifecycle-documents/securing_critical_projects_incubating_stage.md) |
+| Securing Software Repositories | [GitHub](https://github.com/ossf/wg-securing-software-repos)    | [Meeting Notes](https://docs.google.com/document/d/18Y8HxntL2RkcgqoFdhdLpj17e4MOSCdskP1IoDiuP1s/edit)  | Kris Borchers | [Graduated](process/wg-lifecycle-documents/securing_software_repositories_graduation_stage.md) |
+| Security Best Practices        | [GitHub](https://github.com/ossf/wg-best-practices-os-developers) | [Meeting Notes](https://docs.google.com/document/d/1u1gJMtOz-P5Z71B-vKKigzTbIDIS-bUNgNIcfnW4r-k/edit)  | David A. Wheeler | [Graduated](process/wg-lifecycle-documents/BEST_practices_wg_graduation_stage.md)  |
+| Security Tooling               | [GitHub](https://github.com/ossf/wg-security-tooling) | [Meeting Notes](https://docs.google.com/document/d/190urQjwvE6DsjZ3Z1vBbNEXsJ--ccC8xHmbe_fYKRHA/edit) | Jeff Diecks | Incubating |
+| Supply Chain Integrity         | [GitHub](https://github.com/ossf/wg-supply-chain-integrity)  | [Meeting Notes](https://docs.google.com/document/d/1moVFPn5pLi-uGs840_YBCrwdpHajU0ptFmlL4F9GryQ/edit)  | Kris Borchers | Incubating |
+| Vulnerability Disclosures      | [GitHub](https://github.com/ossf/wg-vulnerability-disclosures)  | [Meeting Notes](https://docs.google.com/document/d/1TdxiFofLOfpHUEQILlKq7qkjSsRXVab0uApSDJ8c5rI/edit)     | [Graduated](process/wg-lifecycle-documents/Vuln_Disc_wg_graduation_stage.md) |
 
 
 ### Projects

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 | Security Best Practices        | [GitHub](https://github.com/ossf/wg-best-practices-os-developers) | [Meeting Notes](https://docs.google.com/document/d/1u1gJMtOz-P5Z71B-vKKigzTbIDIS-bUNgNIcfnW4r-k/edit)  | David A. Wheeler | [Graduated](process/wg-lifecycle-documents/BEST_practices_wg_graduation_stage.md)  |
 | Security Tooling               | [GitHub](https://github.com/ossf/wg-security-tooling) | [Meeting Notes](https://docs.google.com/document/d/190urQjwvE6DsjZ3Z1vBbNEXsJ--ccC8xHmbe_fYKRHA/edit) | Jeff Diecks | Incubating |
 | Supply Chain Integrity         | [GitHub](https://github.com/ossf/wg-supply-chain-integrity)  | [Meeting Notes](https://docs.google.com/document/d/1moVFPn5pLi-uGs840_YBCrwdpHajU0ptFmlL4F9GryQ/edit)  | Kris Borchers | Incubating |
-| Vulnerability Disclosures      | [GitHub](https://github.com/ossf/wg-vulnerability-disclosures)  | [Meeting Notes](https://docs.google.com/document/d/1TdxiFofLOfpHUEQILlKq7qkjSsRXVab0uApSDJ8c5rI/edit)     | [Graduated](process/wg-lifecycle-documents/Vuln_Disc_wg_graduation_stage.md) |
+| Vulnerability Disclosures      | [GitHub](https://github.com/ossf/wg-vulnerability-disclosures)  | [Meeting Notes](https://docs.google.com/document/d/1TdxiFofLOfpHUEQILlKq7qkjSsRXVab0uApSDJ8c5rI/edit)  | Jeff Diecks | [Graduated](process/wg-lifecycle-documents/Vuln_Disc_wg_graduation_stage.md) |
 
 
 ### Projects


### PR DESCRIPTION
Updating the working groups table in the TAC readme document with two items:
1. updating each groups meeting notes link to 2025 notes
2. The OpenSSF staff has assigned a point-of-contact to each working group for 2025 to help support the group. Added a column to the table to identify the assigned staff contact for each group.