### PR TITLE
First initial commit for the Malicious Package application 

### DIFF
--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -1,0 +1,30 @@
+## Application for creating a new project at Sandbox stage
+
+### List of project maintainers
+
+Per [project documents](https://github.com/openbao/openbao/blob/main/MAINTAINERS.md):
+
+- Paul McCarty, SourceCodeRED, @6mile
+- Caleb Brown, Google, @calebbrown
+- Jeff Mendoza, Kusari, @jeffmendoza
+
+### Mission of the project
+
+The OpenSSF Malicious Packages project aims to establish and maintain a comprehensive, high-quality, open-source database of reports documenting malicious packages published on open-source package repositories. By collecting, verifying, and sharing these reports in a standardized Open Source Vulnerability (OSV) format, we strive to protect the open-source community from increasingly prevalent threats such as typosquatting, dependency confusion, and account takeovers. Our work provides critical data for the security community to improve detection capabilities and develop better defenses against new open-source malware. Through collaboration with security researchers, package maintainers, and ecosystem stakeholders, we seek to enhance the integrity and security of the open-source supply chain for the benefit of all users.
+
+### IP policy and licensing due diligence
+
+When contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
+  * "yes / no / not applicable. If yes, provide a link to the corresponding GitHub issue."
+
+### Project References
+
+| Reference           | URL |
+|---------------------|-----|
+| Repo                | https://github.com/ossf/malicious-packages|
+| Website             | TBD |
+| Contributing guide  | https://github.com/ossf/malicious-packages/blob/main/CONTRIBUTING.md |
+| Security.md         | https://github.com/ossf/malicious-packages/blob/main/SECURITY.md |
+| Roadmap             | TBD |
+| Demos               | n/a |
+| Other               | TBD |


### PR DESCRIPTION
This is my initial draft doc for the TAC requirement to create a separate OpenSSF project for Malicious Packages.
The intent is to spin Malicious Packages out of the Securing Critical Projects WG and into its own project.