### PR TITLE
Application for sandbox stage with cve-bin-tool

### DIFF
--- a/process/project-lifecycle-documents/cve-bin-tool_sandbox_stage.md
+++ b/process/project-lifecycle-documents/cve-bin-tool_sandbox_stage.md
@@ -1,0 +1,40 @@
+## Application for creating a new project at Sandbox stage
+
+### List of project maintainers
+
+The project must have a minimum of three maintainers with a minimum of two different organizational affiliations.
+
+* Terri Oda, non-affiliated, @terriko
+* Anthony Harrison, APH10, @anthonyharrison
+* Fabrice Fontaine, Orange, @ffontaine
+* Sanskar Sharma, Nirmata, @mastersans
+* Steve Miller, Intel, @stvml
+
+### Sponsor
+
+* OpenSSF Security Tooling WG
+
+### Mission of the project
+
+The CVE Binary Tool helps you determine if your system includes known vulnerabilities. You can scan binaries for over 400 common, vulnerable components (openssl, libpng, libxml2, expat and others), or if you know the components used, you can get a list of known vulnerabilities associated with an SBOM or a list of components and versions.
+
+### IP policy and licensing due diligence
+
+Project License is GPLv3+ and component list has previously been reviewed by the licensing team at Intel corporation.  It has not yet been reviewed by the Linux Foundationn.
+
+* [SBOM for Python 3.13 in SPDX format](https://github.com/intel/cve-bin-tool/blob/main/sbom/cve-bin-tool-py3.13.spdx)
+* [SBOMS in other formats and for other versions of python](https://github.com/intel/cve-bin-tool/tree/main/sbom)
+  
+### Project References
+
+The project should provide a list of existing resources with links to the repository, and if available, website, a roadmap, contributing guide, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the project.
+
+| Reference           | URL |
+|---------------------|-----|
+| Repo                |  https://github.com/intel/cve-bin-tool/   |
+| Website             |  https://cve-bin-tool.readthedocs.io/en/latest/   |
+| Contributing guide  |  https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md   |
+| Security.md         |  https://github.com/intel/cve-bin-tool/blob/main/SECURITY.md   |
+| Roadmap             |  https://github.com/intel/cve-bin-tool/milestones   |
+| Demos               |  https://github.com/intel/cve-bin-tool/tree/main/presentation   |
+| Other               |     |


### PR DESCRIPTION
As per conversation with the Tools WG this morning.  Intel is looking to transfer cve-bin-tool to an open source foundation because I (as primary maintainner) am leaving the company, and we're hoping the OpenSSF can be our new home.  

The CVE Binary Tool helps you determine if your system includes known vulnerabilities. You can scan binaries for over 400 common, vulnerable components (openssl, libpng, libxml2, expat and others), or if you know the components used, you can get a list of known vulnerabilities associated with an SBOM or a list of components and versions.

As far as I know, we're one of very few _binary_ vulnerability scanners that's free, open source, and allows you to get a list of vulnerabilities or an SBOM from the results.   

Tagging our current maintainer team (other than myself) in case I made a typo in your name/affiliation:
@anthonyharrison @ffontaine @mastersans @stvml

And tagging @ware as promised!