### PR TITLE
Move Minder to the ORBIT WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 | OpenSSF Scorecard | [GitHub](https://github.com/ossf/scorecard)                | https://securityscorecards.dev/ | Best Practices WG | [Incubating](/process/project-lifecycle-documents/openssf_scorecard_incubating_stage.md) |
 | OpenVEX | [GitHub](https://github.com/openvex) |  | Vulnerability Disclosures WG | [Sandbox](process/project-lifecycle-documents/openvex_for_sandbox_stage.md) |
 | OSV Schema             | [GitHub](https://github.com/ossf/osv-schema)               | https://ossf.github.io/osv-schema/ | Vulnerability Disclosures WG   | TBD        |
-| Minder                 | [GitHub](https://github.com/mindersec/minder)         |  | Security Tooling WG            | [Sandbox](process/project-lifecycle-documents/minder_sandbox_stage.md) |
+| Minder                 | [GitHub](https://github.com/mindersec/minder)         | https://mindersec.dev/ | ORBIT WG            | [Sandbox](process/project-lifecycle-documents/minder_sandbox_stage.md) |
 | Model signing          | [GitHub](https://github.com/sigstore/model-transparency/blob/main/README.model_signing.md) |  | AI/ML Security WG | [Sandbox](process/project-lifecycle-documents/model_signing_sandbox_stage.md) |
 | Package Analysis       | [GitHub](https://github.com/ossf/package-analysis)         |  | Securing Critical Projects WG   | TBD        |
 | Protobom | [GitHub](https://github.com/protobom/protobom) |  | Security Tooling WG | [Sandbox](process/project-lifecycle-documents/protobom_sandbox_stage.md) |

--- a/process/project-lifecycle-documents/minder_sandbox_stage.md
+++ b/process/project-lifecycle-documents/minder_sandbox_stage.md
@@ -20,7 +20,7 @@ The project has [11 maintaners](https://github.com/stacklok/minder/blob/main/MAI
 
 Most projects will report to an existing OpenSSF Working Group, although in some cases a project may report directly to the TAC. The project commits to providing quarterly updates on progress to the group they report to.
 
-  * [Security Tooling WG](https://github.com/ossf/wg-security-tooling)
+  * [ORBIT WG](https://github.com/ossf/wg-orbit)
 
 ### Mission of the project
 
@@ -46,11 +46,11 @@ The project should provide a list of existing resources with links to the reposi
 
 | Reference           | URL |
 |---------------------|-----|
-| Repo                | https://github.com/stacklok/minder |
-| Website             | https://minder-docs.stacklok.dev |
-| Contributing guide  | https://github.com/stacklok/minder/blob/main/CONTRIBUTING.md |
-| Security.md         | https://github.com/stacklok/minder/blob/main/SECURITY.md |
-| Roadmap             | https://minder-docs.stacklok.dev/about/roadmap |
+| Repo                | https://github.com/mindersec/minder |
+| Website             | https://mindersec.dev/ (splash page) and https://mindersec.github.io |
+| Contributing guide  | https://github.com/mindersec/minder/blob/main/CONTRIBUTING.md |
+| Security.md         | https://github.com/mindersec/minder/blob/main/SECURITY.md |
+| Roadmap             | https://mindersec.github.io/about/roadmap |
 | Demos               | https://www.youtube.com/watch?v=WniqzgNHjJQ (a little dated) |
-| Discord Community   | https://discord.com/channels/1184987096302239844/1185287949240242258 |
+| OpenSSF Slack       | [#minder](https://openssf.slack.com/archives/C07SP9RSM2L) |
 | Other               |     |


### PR DESCRIPTION
When Minder was submitted to the OpenSSF, there was not a clear fit for the project in the existing working groups.  The ORBIT (Open Resources for Baselines, Interoperability, and Tooling) seems like a clearer fit for Minder's ability to assess repositories and other supply chain resources for policy and control compliance, as we are actively participating in baseline conversations and looking to build automated assessments and remediations for baseline controls.



This records the move; it also updates the Security Insights Spec and Security Baseline project's move to the ORBIT WG. 

