### PR TITLE
Revise TAC and SCIR election timeline

### DIFF
--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -68,7 +68,7 @@ Questions related to the nomination and/or election process should be directed t
 
 ## Appointment Process
 
-The Governing Board will appoint three people from the list of TAC and SCIR Nominees excluding those who got elected. The Governing Board will be provided with the results of the election from the community so that they can ensure appropriate diversity of the TAC during their vote.
+The Governing Board will appoint three people pulling from the list of TAC and SCIR Nominees excluding those who got elected and those they nominate. The Governing Board will be provided with the results of the election from the community so that they can ensure appropriate diversity of the TAC during their vote.
 
 
 ## TAC Chair and Vice Chair Election
@@ -113,28 +113,25 @@ About 10 months after the previous cycle, a committee of Election Officials will
 | October 23 - October 24 | Validation Period of nominee submissions
 | October 27 | Slate of respective nominees and ballot or link to an electronic voting system sent to registered voters.
 | November 9 | The voting period ends at 11:59 pm PDT
-| November 10 | The election winners announced
+| November 11 | The election winners announced
 
-[Community Election Self-Nomination Form]
+**[Community Election Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLScNzK_8bApE7mIvTZpFuP00Lmc6syQkPGe-JYGekp37DSswtQ/viewform?usp=dialog)**
 
-[SCIR Self-Nomination Form]
-
+**[SCIR Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSe-9A1I0LM2BJA5_TOGADxUapvAdzgZHsF7IwnURqEZJJigaQ/viewform?usp=dialog)**
 
 **Governing Board Appointed Seat Timeline**
 
 | Date | Action |
 | :--- | :--- |
 | November 10 | Call for nominations; notice given to GB Members and include results from the community election.
-| November 23 | End nomination period, 11:59 PM PST.
-| November 24 | The slate of respective nominees and ballot or link to an electronic voting system sent to governing board primary voting representatives.
-| December 1 | Send an email reminder to GB members.
-| December 7 | The voting period ends at 11:59 PM PST.
-| December 8 | The GB-appointed TAC representatives announced.
+| November 16 | End nomination period, 11:59 PM PST.
+| November 17 | The slate of respective nominees and ballot or link to an electronic voting system sent to the governing board primary voting representatives.
+| November 30 | The voting period ends at 11:59 PM PST.
+| December 2 | The GB-appointed TAC representatives announced.
 
- **New members seated: January 1**
+ **New members seated: January 1, 2026**
 
 
 ## Voter Registration form
 
-The electorate can request a ballot by filling out this [Google Form].
-
+The electorate can request a ballot by filling out this **[Google Form](https://docs.google.com/forms/d/e/1FAIpQLScpX1Fdlvcj_9JwYVzQlDQrgHfXWSd8v9ruc2ZKmrfq4Yf5lQ/viewform?usp=dialog).**

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -68,7 +68,12 @@ Questions related to the nomination and/or election process should be directed t
 
 ## Appointment Process
 
-The Governing Board will appoint three people pulling from the list of TAC and SCIR Nominees excluding those who got elected and those they nominate. The Governing Board will be provided with the results of the election from the community so that they can ensure appropriate diversity of the TAC during their vote.
+The Governing Board will appoint three (3) seats on the Technical Advisory Council. These individuals will be selected from the following nominee categories:
+
+- TAC and SCIR nominees for the current election who were _not_ elected
+- individuals from [OpenSSF member organizations](https://openssf.org/about/members/) that are nominated by Governing Board representatives 
+
+The Governing Board will be provided with the results of the election from the community so that they can ensure appropriate diversity of the TAC during their vote.
 
 
 ## TAC Chair and Vice Chair Election

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -120,7 +120,7 @@ About 10 months after the previous cycle, a committee of Election Officials will
 | November 9 | The voting period ends at 11:59 pm PDT
 | November 11 | The election winners announced
 
-**[Community Election Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLScNzK_8bApE7mIvTZpFuP00Lmc6syQkPGe-JYGekp37DSswtQ/viewform?usp=dialog)**
+**[Community Election Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLScNzK_8bApE7mIvTZpFuP00Lmc6syQkPGe-JYGekp37DSswtQ/viewform)**
 
 **[SCIR Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSe-9A1I0LM2BJA5_TOGADxUapvAdzgZHsF7IwnURqEZJJigaQ/viewform?usp=dialog)**
 

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -122,7 +122,7 @@ About 10 months after the previous cycle, a committee of Election Officials will
 
 **[Community Election Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLScNzK_8bApE7mIvTZpFuP00Lmc6syQkPGe-JYGekp37DSswtQ/viewform)**
 
-**[SCIR Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSe-9A1I0LM2BJA5_TOGADxUapvAdzgZHsF7IwnURqEZJJigaQ/viewform?usp=dialog)**
+**[SCIR Self-Nomination Form](https://docs.google.com/forms/d/e/1FAIpQLSe-9A1I0LM2BJA5_TOGADxUapvAdzgZHsF7IwnURqEZJJigaQ/viewform)**
 
 **Governing Board Appointed Seat Timeline**
 

--- a/elections/tac-and-scir-election-process.md
+++ b/elections/tac-and-scir-election-process.md
@@ -139,4 +139,4 @@ About 10 months after the previous cycle, a committee of Election Officials will
 
 ## Voter Registration form
 
-The electorate can request a ballot by filling out this **[Google Form](https://docs.google.com/forms/d/e/1FAIpQLScpX1Fdlvcj_9JwYVzQlDQrgHfXWSd8v9ruc2ZKmrfq4Yf5lQ/viewform?usp=dialog).**
+The electorate can request a ballot by filling out this **[Google Form](https://docs.google.com/forms/d/e/1FAIpQLScpX1Fdlvcj_9JwYVzQlDQrgHfXWSd8v9ruc2ZKmrfq4Yf5lQ/viewform).**


### PR DESCRIPTION
Updated election timeline and clarified the GB-appointment process to include them being able to nomiante and pull from the community list.