### PR TITLE
gitvote: Vote close and status check updates

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -2,12 +2,12 @@ profiles:
   default:
     duration: 2w
     pass_threshold: 55
-    periodic_status_check: "1 week"
+    periodic_status_check: "4 days"
     allowed_voters:
       teams:
         - tac
       exclude_team_maintainers: true
-    close_on_passing: true
+    close_on_passing: false
     announcements:
       discussions:
         category: announcements


### PR DESCRIPTION
Discussed on [2025-11-11's TAC meeting](https://docs.google.com/document/d/1EieWyhKntZ7BzaZS97-BOybfMTUT4sZ72ViXq8QyYWs/edit?pli=1&tab=t.0#bookmark=id.rvmqmvaevt6s):

- `close_on_passing: false` — Votes will now close at the end of
  the `duration` period, instead of as soon as the `pass_threshold`
  has been satisfied. This will allow TAC members to express their
  perspectives throughout the duration period, which can be useful
  for certain votes, like funding proposals.
- `periodic_status_check: "4 days"` — Increase the periodic status
  check frequency from 1 week to 4 days. This effectively adds an
  additional 1–2 automated, non-staff-elicited status checks to the
  current two-week voting period.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @ossf/tac @kj-powell 