### PR TITLE
Add question about funding request to TI report template

### DIFF
--- a/TI-reports/0000-quarterly-update-template.md
+++ b/TI-reports/0000-quarterly-update-template.md
@@ -19,8 +19,11 @@
 
 ### Up Next
 
-### Questions/Issues for the TAC
+### Funding requests
 
+<mark>Are you considering applying for any [funding requests](https://github.com/ossf/tac/blob/main/process/TI%20Funding%20Request%20Process.md)?</mark>
+
+### Questions/Issues for the TAC
 
 ## Additional Information
 


### PR DESCRIPTION
Following up on the 01/06/2026 TAC call, this PR proposes to add to the TI report template a question about funding requests.

The goal is to provide the TAC with some insight as to what TIs might be planning as well as ensuring TIs are aware of the funding opportunity and prompt them to consider making a request.

I considered addressing this as part of the existing "Questions/Issues for the TAC" section but it's simpler to just add a new section.