### PR TITLE
Adding references to the MVVSR to lifecycle documents and TI applications

### DIFF
--- a/process/project-lifecycle.md
+++ b/process/project-lifecycle.md
@@ -8,7 +8,7 @@ New [Projects](../organizational-structure-overview.md#definitions) to the OpenS
 
 ## Project Oversight
 
-Projects report either directly to the Technical Advisory Council (TAC) or to a specific Working Group (WG). When a Project reports into a specific WG, that WG can support the Project's progression and provide recommendations to the TAC. The overseeing group provides Projects advice on technical direction, and is a point of escalation or dispute resolution in technical disagreements. The overseeing group does not set the charter or operations for Projects, but ensures Projects operate in line with the [OpenSSF values.](https://openssf.org/about/values/) 
+Projects report either directly to the Technical Advisory Council (TAC) or to a specific Working Group (WG). When a Project reports into a specific WG, that WG can support the Project's progression and provide recommendations to the TAC. The overseeing group provides Projects advice on technical direction, and is a point of escalation or dispute resolution in technical disagreements. The overseeing group does not set the charter or operations for Projects, but ensures Projects operate in line with the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/).
 
 <!-- TOC -->
 

--- a/process/sig-lifecycle.md
+++ b/process/sig-lifecycle.md
@@ -1,6 +1,6 @@
 # Special Interest Group (SIG) Life Cycle
 
-Special Interest Groups are bound to achieving a very specific goal. These groups may be terminated upon completion of their designating tasking or continued for larger and ongoing efforts. The creation of a SIG must dictate the focus, intent, goals, and deliverable(s) as appropriate. SIGs may report to a WG or directly to the TAC as their governing body.
+Special Interest Groups are bound to achieving a very specific goal. These groups may be terminated upon completion of their designating tasking or continued for larger and ongoing efforts. The creation of a SIG must dictate the focus, intent, goals, and deliverable(s) as appropriate. SIGs must align with and contribute to the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/) of the OpenSSF. SIGs may report to a WG or directly to the TAC as their governing body.
 
 It is expected that the primary output of a SIG is not software. If the primary output is software, the work should be organized as a [project](./project-lifecycle.md).
 

--- a/process/templates/PROJECT_NAME_incubation_stage.md
+++ b/process/templates/PROJECT_NAME_incubation_stage.md
@@ -11,6 +11,15 @@ The project must have a minimum of three maintainers with a minimum of two diffe
 The project must be aligned with the OpenSSF mission and either be a novel approach for existing areas, address an unfulfilled need, or be code needed to deliver OpenSSF WG work. It is preferred that extensions of existing OpenSSF projects collaborate with the existing project rather than seek a new project.
   * "description of the project mission"
 
+### Alignment with the OpenSSF MVSSR
+The mission of the Project must be aligned with the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/) of the OpenSSF. Please indicate to which of the three strategies and four pillars of the OpenSSF the Project contributes to.
+
+Strategies: *i) Catalyst for Change*, *ii) Educate and Empower the Modern Developer*, *iii) Ecosystem Leader*
+  * "describe which strategy(ies) the Project contribute(s) to"
+
+Pillars: *i) Programs & Projects, ii) Education, iii) Public Policy, iv) Community & Events*
+  * "describe which pillar(s) the Project contribute(s) to"
+
 ### Project adoption
 The project should be able to show adoption by multiple parties and the adoption's value to the open source community and/or end users (may include adoption of beta/early versions).
   * "description of adoption"

--- a/process/templates/PROJECT_NAME_sandbox_stage.md
+++ b/process/templates/PROJECT_NAME_sandbox_stage.md
@@ -12,6 +12,15 @@ Most projects will report to an existing OpenSSF Working Group, although in some
 The project must be aligned with the OpenSSF mission and either be a novel approach for existing areas, address an unfulfilled need, or be initial code needed for OpenSSF WG work. It is preferred that extensions of existing OpenSSF projects collaborate with the existing project rather than seek a new project.
   * "description of the project mission"
 
+### Alignment with the OpenSSF MVSSR
+The mission of the Project must be aligned with the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/) of the OpenSSF. Please indicate to which of the three strategies and four pillars of the OpenSSF the Project contributes to.
+
+Strategies: *i) Catalyst for Change*, *ii) Educate and Empower the Modern Developer*, *iii) Ecosystem Leader*
+  * "describe which strategy(ies) the Project contribute(s) to"
+
+Pillars: *i) Programs & Projects, ii) Education, iii) Public Policy, iv) Community & Events*
+  * "describe which pillar(s) the Project contribute(s) to"
+
 ### IP policy and licensing due diligence
 When contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
   * "yes / no / not applicable. If yes, provide a link to the corresponding GitHub issue."

--- a/process/templates/SIG_NAME_incubating_stage.md
+++ b/process/templates/SIG_NAME_incubating_stage.md
@@ -17,8 +17,8 @@ SIG has defined group governance
 ### SIG References
 The SIG should provide a list of existing resources with links to the repository, and if available, website, a roadmap, demos and walkthroughs, and any other material to showcase the existing breadth, maturity, and direction of the SIG.
 
- Reference           | URL |
-|---------------------|-----|
+ Reference              | URL |
+|-----------------------|-----|
 | Repo                  |     |
 | Meeting Agenda        |     |
 | OSSF Calendar Entry   |     |

--- a/process/templates/SIG_NAME_sandbox_stage.md
+++ b/process/templates/SIG_NAME_sandbox_stage.md
@@ -1,8 +1,16 @@
 ## Creation of a new Special Interest Group (SIG) at Sandbox stage
 
 ### Proposed focus, intent, goals, and/or deliverables
-
   * Link to relevant documentation.
+
+### Alignment with the OpenSSF MVSSR
+The SIG must be aligned with the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/) of the OpenSSF. Please indicate to which of the three strategies and four pillars of the OpenSSF the SIG contributes to.
+
+Strategies: *i) Catalyst for Change*, *ii) Educate and Empower the Modern Developer*, *iii) Ecosystem Leader*
+  * "describe which strategy(ies) the SIG contribute(s) to"
+
+Pillars: *i) Programs & Projects, ii) Education, iii) Public Policy, iv) Community & Events*
+  * "describe which pillar(s) the SIG contribute(s) to"
 
 ### List SIG Lead(s)
 The SIG must have a minimum of 1 Lead

--- a/process/templates/WG_NAME_incubating_stage.md
+++ b/process/templates/WG_NAME_incubating_stage.md
@@ -15,6 +15,15 @@ The WG must have a minimum of 5 contributors from at least 3 different organizat
 The WG must have a charter or mission statement for review by TAC
   * Link to the WG charter or mission statement defining its goals.
 
+### Alignment with the OpenSSF MVSSR
+The mission of the WG must be aligned with the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/) of the OpenSSF. Please indicate to which of the three strategies and four pillars of the OpenSSF the WG is contributing to.
+
+Strategies: *i) Catalyst for Change*, *ii) Educate and Empower the Modern Developer*, *iii) Ecosystem Leader*
+  * "describe which strategy(ies) the WG contribute(s) to"
+
+Pillars: *i) Programs & Projects, ii) Education, iii) Public Policy, iv) Community & Events*
+  * "describe which pillar(s) the WG contribute(s) to"
+
 ### Governance
 WG must have documented, initial group governance.
   * Link to initial group governance doc

--- a/process/templates/WG_NAME_sandbox_stage.md
+++ b/process/templates/WG_NAME_sandbox_stage.md
@@ -5,8 +5,17 @@ The WG must have a minimum of 3 interested contributors from two different organ
   * "name, affiliation, GitHub ID"
 
 ### Mission of the Working Group
-The WG must be aligned with the OpenSSF mission and address an unfulfilled need. It is preferred that topics falling with the scope of existing OpenSSF WGs are addressed within the existing wG rather than seek a new WG.
+The WG must be aligned with the OpenSSF mission and address an unfulfilled need. It is preferred that topics falling with the scope of existing OpenSSF WGs are addressed within an existing WG rather than seek a new WG.
   * "description of the WG mission"
+
+### Alignment with the OpenSSF MVSSR
+The mission of the WG must be aligned with the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/) of the OpenSSF. Please indicate to which of the three strategies and four pillars of the OpenSSF the WG is contributing to.
+
+Strategies: *i) Catalyst for Change*, *ii) Educate and Empower the Modern Developer*, *iii) Ecosystem Leader*
+  * "describe which strategy(ies) the WG contribute(s) to"
+
+Pillars: *i) Programs & Projects, ii) Education, iii) Public Policy, iv) Community & Events*
+  * "describe which pillar(s) the WG contribute(s) to"
 
 ### IP policy and licensing due diligence
 When contributing to OpenSSF any existing material for the new WG to work on, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
@@ -23,5 +32,5 @@ The WG should provide a list of existing resources with links to the repository,
 |---------------------|-----|
 | Repo                |     |
 | Website             |     |
-| Security.md    |     |
+| Security.md         |     |
 | Other               |     |

--- a/process/working-group-lifecycle.md
+++ b/process/working-group-lifecycle.md
@@ -4,7 +4,7 @@ Working Groups are under the governance of the Technical Advisory Committee (TAC
 
 Contributors interested in starting a new WG are encouraged to first review the existing WGs and projects. It is very likely that an existing WG could be extended to cover the new topic. If this is the case, please bring your time and energy into that existing working group. Your contributions are very welcome!
 
-However, if no existing effort covers the topic feel free to make use of the existing WG meetings, mailing lists, and/or Slack channels to solicit support for a new WG.
+However, if no existing effort covers the topic feel free to make use of the existing WG meetings, mailing lists, and/or Slack channels to solicit support for a new WG. WGs must align with and contribute to the [Mission, Vision, Values, Strategy, and Roadmap (MVVSR)](https://openssf.org/about/) of the OpenSSF.
 
 Please note that running a WG successfully requires an extended effort. Be prepared to commit at least several hours per week for a year or more.
 


### PR DESCRIPTION
Clarifying in our lifecycle documents that all TIs must align with the MVVSR or the OpenSSF.

New TIs must now indicate in their applications how they contribute to the MVSSR (strategy). This question is omitted for graduating TIs as they have already been accepted into the OpenSSF and answered it as part of the sandbox or incubation application.

Fixes #550 