### PR TITLE
Add 2026 Q1 Vulnerability Disclosure WG quarterly report

### DIFF
--- a/TI-reports/2026/2026-Q1-VD-WG.md
+++ b/TI-reports/2026/2026-Q1-VD-WG.md
@@ -1,0 +1,86 @@
+# 2026 Q1 Vulnerability Disclosure WG
+
+## Overview
+
+**Mission**: The OpenSSF Vulnerability Disclosures Working Group seeks to help improve the overall security of the open source software ecosystem by helping develop and advocate well-managed vulnerability reporting and communication. We serve open source maintainers and developers, assist security researchers, and help downstream open source software consumers.
+
+The Vulnerability Disclosure Working Group is officially a [Graduated-level](https://github.com/ossf/tac/blob/main/process/working-group-lifecycle.md) working group within the OpenSSF. Last WG TI update was [2025 Q3](https://github.com/ossf/tac/blob/main/TI-reports/2025/2025-Q3-VD-WG.md).
+
+Community health remains stable with consistent meeting attendance. The AMER meeting typically sees 5–14 attendees, and the APAC meeting has maintained its upward attendance trend and recently increased its meeting cadence from monthly to twice a month. Key highlights this quarter include:
+
+- Continued progress on the **OSV Schema graduation** application.
+- Active efforts to combat low-quality **AI-generated vulnerability reports** ("AI slop") and related consensus on vulnerability definitions.
+- Started efforts to establish a recommendation for encouraging and requiring maintainers to **provide sufficient security contact information**.
+
+**WG Project Board:** https://github.com/orgs/ossf/projects/29
+
+## OSV Schema Graduation
+
+### Purpose
+
+The OSV (Open Source Vulnerability) schema existed prior to the current OpenSSF project maturity model. The purpose of this activity is to formally bring the OSV project schema into compliance with OpenSSF's "graduated" security requirements, ensuring its continued robustness and alignment with broader community standards.
+
+### Current Status
+
+- The [graduation application PR](https://github.com/ossf/tac/pull/456) continues to be worked on in the OpenSSF TAC repository.
+  - Work continues on [implementing the security baseline](https://github.com/ossf/osv-schema/issues?q=state%3Aopen%20label%3A%22security%20baseline%22) requirements ([tracking spreadsheet](https://microsoft-my.sharepoint.com/:x:/r/personal/madoliver_microsoft_com/Documents/OSV%20Schema%20Graduated%20Security%20Baseline%20Requirements.xlsx?d=we6f50d9d71405966921e209d7a6ba6fe&csf=1&web=1&e=sQDJEV)).
+  - Level 1: complete, Level 2: 88% complete, Level 3: 30% complete.
+
+### Up Next
+
+- Complete remaining graduation requirements.
+
+## Maintainer Contact Info & CRA Compliance
+
+### Purpose
+
+To establish a recommendation for encouraging and requiring maintainers to provide sufficient security contact information (CVD, CNA, Open Source Steward) in support of upcoming mandates like the European Cyber Resilience Act (CRA), and to support the OpenSSF VulnDB.
+
+### Current Status
+
+- https://github.com/ossf/wg-vulnerability-disclosures/issues/175
+- Discussion recommending `SECURITY.TXT`, the role of CRA Open Source Stewards, and whether Scorecard can help determine how many projects already have this information.
+- A three-step proposal was developed:
+  1. Update `SECURITY.txt` with standardized contact fields.
+  2. Enable autodiscovery by coordinating with Scorecard and other scanning tools.
+  3. Encode this information in package registries and platforms like GitHub.
+- The WG also discussed BSI's Guidance on Implementing the CRA Requirements.
+
+### Up Next
+
+- Continue developing https://github.com/ossf/wg-vulnerability-disclosures/issues/175
+
+## AI-Generated Report Quality ("AI Slop")
+
+### Purpose
+
+To address the growing burden on open-source maintainers caused by low-quality, often AI-generated, vulnerability reports and find actionable ways to empower maintainers.
+
+### Current Status
+
+- Active discussion stemming from community Slack threads and a post by Seth Larson, with updates from the CRS SIG (Jeff Diecks).
+- The WG acknowledged that much of the burden for evaluating these reports falls disproportionately on maintainers.
+- Discussion held on whether to add language to the inbound security policy guide to address AI-generated reports.
+- The WG reached consensus on vulnerability definitions: "if there is no net gain in access, there is no vulnerability," and maintainers should evaluate whether an attack can still succeed when default security features are active.
+- This topic was initially raised in December 2024 and has continued as an active discussion into 2026.
+
+### Up Next
+
+- Update the VDWG's vulnerability guides for maintainers and reporters to include guidance on evaluating and recognizing AI-generated reports.
+- Create an issue in the vulnerability disclosures repo for a discussion post on vulnerability definitions.
+
+## Additional Activities & Updates
+
+### Criticality Project
+- Caleb Brown of Google's open source security team provided an overview of the Criticality project and its connections to the malicious packages repository and package analysis project.
+- The project may move to the VDWG as part of a proposed OpenSSF working group reorganization.
+
+### VDWG Automation Best Practices SIG
+- The WG is evaluating the creation of a new SIG focused on best practices for automation within vulnerability disclosure. Discussion and formalization are in progress.
+- https://github.com/ossf/open-auto-vuln-disclose remains on hold, but is prior art that the WG can pull from. 
+
+### Previous Updates
+- [2025 Q3](https://github.com/ossf/tac/blob/main/TI-reports/2025/2025-Q3-VD-WG.md)
+- [2025 Q2](https://github.com/ossf/tac/blob/main/TI-reports/2025/2025-Q2-VD-WG.md)
+- [2025 Q1](https://github.com/ossf/tac/blob/main/TI-reports/2025/2025-Q1-Vulnerability-Disclosure-WG.md)
+- [2024 Q4](https://github.com/ossf/tac/blob/main/TI-reports/2024/2024-Q4-VULN-WG.md)


### PR DESCRIPTION
This pull request adds the 2026 Q1 report for the Vulnerability Disclosure Working Group (VDWG). The report summarizes the group's ongoing initiatives, progress on key projects, and community health. Major updates include progress on OSV Schema graduation, addressing AI-generated vulnerability reports, and efforts to improve maintainer security contact information.