### PR TITLE
Add 2026 Q1 TAC Report for Global Cyber Policy WG

### DIFF
--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -27,7 +27,6 @@ Since our last report, we held two tech talks:
 
 * We collaborated with others in a successful [CRA In Pracitce](https://fosdem.org/2026/schedule/track/cra-in-practice/) dev room at FOSDEM.
 
-* We continued work on specifying a "compliance" file for OSS repos - that would include information about stewardship as well as additional info: https://github.com/ossf/wg-globalcyberpolicy/issues/69. It's already referenced as a "good practice" by the CRA Voluntary Security Attestation Project (Eclipse ORC WG)
 
 * We have updated the page at https://policy.openssf.org
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -40,7 +40,7 @@ Since our last report, we held two tech talks:
 
 ## Awareness SIG
 
-The awareness SIG is led by [Megan Knight](https://github.com/businesscasualkesha) of Arm. The scope is activities that drive awareness of the work of this group and of the regulatory landscape in general. The SIG has been marshalling blog posts, upcoming conference schedule, as well as the CRA introductory course. The Awareness SIG minutes are kept in the [main working group minutes document](https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit). 
+The awareness SIG is led by [Megan Knight](https://github.com/businesscasualkesha) of Arm. The scope is activities that drive awareness of the work of this group and of the regulatory landscape in general. The SIG has been marshalling blog posts and the upcoming conference schedule. The Awareness SIG minutes are kept in the [main working group minutes document](https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit). 
 
 Activities and Publications: [pending]
 * On 2026-02-25, Linux Foundation Member Summit, "CRA: Ask Us Anything" was led by Christopher "CRob" Robinson and David A. Wheeler; "Security through Education: Meeting AI, CRA, and Supply Chain Challenges in Software Development" was presented by David A. Wheeler

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -10,7 +10,7 @@ This group has celebrated its 1st year of operation, having been been formed in 
 
 In late 2025, the group ran some workshop sessions at the LF Europe Roadshow event in Ghent and subsequent policy summit in Brussels to refine its scope and deliverables for 2026. For example, we added an emphasis on case studies and producing guidelines that would be useful to "manufacturers."
 
-We have two working group co-leads: [Daniel Appelquist | Samsung](https://github.com/torgo) and [Roman Zhukov | Red Hat](https://github.com/rozhukov). [Megan Knight | Arm](https://github.com/businesscasualkesha) chairs the Awareness SIG and [Madalin Neag](https://github.com/madalinnneag) from OpenSSF staff chairs the Standards SIG. In addition, we have support from [Jeff Diecks](https://github.com/GeauxJD], [Crob](https://github.com/SecurityCRob) and [David A. Wheeler](https://github.com/david-a-wheeler).
+We have two working group co-leads: [Daniel Appelquist | Samsung](https://github.com/torgo) and [Roman Zhukov | Red Hat](https://github.com/rozhukov). [Megan Knight | Arm](https://github.com/businesscasualkesha) chairs the Awareness SIG and [Madalin Neag](https://github.com/madalinnneag) from OpenSSF staff chairs the Standards SIG. In addition, we have support from [Jeff Diecks](https://github.com/GeauxJD), [Crob](https://github.com/SecurityCRob) and [David A. Wheeler](https://github.com/david-a-wheeler).
 
 We also operate the "EU CRA Monthly Tech Talk".
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -47,6 +47,16 @@ Activities and Publications: [pending]
 
 ## Standards SIG
 
+The Standards SIG is led by [Madalin Neag](https://github.com/madalinnneag).
+
+The mission of the Standardization SIG has been to coordinate stakeholder engagement on cybersecurity standards related to policy, with a focus on raising awareness of standards development activities connected to the CRA. The SIG has also monitored complementary standards initiatives and policy developments to ensure members maintain visibility into the evolving regulatory and standardization landscape.
+
+The group has supported the involvement of OpenSSF members and staff in standards activities by serving as a coordination forum to guide engagement strategies across European Standards Organizations (ESOs) and other SDOs, particularly where confidentiality practices differ from those typically used in open source communities. Through this coordination, OpenSSF representatives have enabled participation by sharing knowledge and updates, advocating for open source values, and coordinating community-level feedback on key deliverables, including the [CEN](https://www.cencenelec.eu/about-cen/) horizontal standards (such as PT1 and PT3 - see [standards map](https://policy.openssf.org/CRA/standards.html) for detail).
+
+A core component of the SIG’s work has been facilitating community’s participation in public consultations related to cybersecurity standards and policy. The group has raised awareness of consultation opportunities, shared relevant information, and coordinated the consolidation of feedback so that responses reflect the collective expertise of the OpenSSF community.
+
+The SIG has also acted as an information-sharing platform on related policy developments, standards initiatives, funding opportunities, and key steps for CRA implementation, including updates on delegated and implementing acts, guidance materials, roadmaps, and developments from relevant European institutions and authorities.
+
 The Standards SIG is led by [Madalin Neag](https://github.com/madalinnneag). 
 
 The SIG's mission has been to coordinate between stakeholders regarding engagement in Standards work related to cybersecurity policy. This is complicated by the fact that many of these standards organizations have a different approach to confidentiality than the OpenSSF. The discussions of this group have helped to guide the engagement of OpenSSF staff within some of these efforts.

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -25,7 +25,7 @@ Since our last report, we held two tech talks:
 * one where Launchpad SIG was presented. [Recording is available here](https://zoom.us/rec/share/X5PE2JoOyLac15HXB-0eGm9avCPSrRuwfmZD7Uy2QCwq5mYkAqla--O6_fD7eYcr.AL_bBxDGeZD8SejU) and the slides are [available here](https://drive.google.com/file/d/17b-dUihdJJ-i6URvY6mqLWKLq4Cata8B/view?usp=sharing)
 * one where we discussed our approach for stewardship and the documents that our community has developed. [Recording here](https://zoom.us/rec/play/vu7ETuGu10UZt3TUlZDNT597n8j8tEds1kFOjxOuLQimwYxHRf4nCcYFFbo54N_9qFOb4NfQdiIHR4fG.Br30pNufDbHGCo6P?eagerLoadZvaPages=sidemenu.billing.plan_management&accessLevel=meeting&canPlayFromShare=true&from=share_recording_detail&continueMode=true&componentName=rec-play&originRequestUrl=https%3A%2F%2Fzoom.us%2Frec%2Fshare%2FuiUTy3JAmVUI_CGYQFLXjhpeCUbsDrwb3J55n_IzFyBbKqSfuEyZ3yWi_ZUscVIz.qW8ITyi-A9YBLTvp)
 
-* We collaborated with others in a successful [CRA In Pracitce](https://fosdem.org/2026/schedule/track/cra-in-practice/) dev room at FOSDEM.
+* We collaborated with others in a successful [CRA In Practice](https://fosdem.org/2026/schedule/track/cra-in-practice/) dev room at FOSDEM.
 
 
 * We have updated the page at https://policy.openssf.org

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -14,7 +14,9 @@ We have two working group co-leads: [Daniel Appelquist | Samsung](https://github
 
 We also operate the "EU CRA Monthly Tech Talk".
 
-We have a regular schedule of calls for our Awareness and Standards SIGs and take minutes in our main minutes doc.
+We have a regular schedule of calls for our Awareness and Standards SIGs and take minutes in the following minutes docs:
+* Main WG/Awareness SIG: https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit?tab=t.0
+* Standards SIG: https://docs.google.com/document/d/1XjE5VYdyIdH32T94ZQIj0Hf5btRiKG58z3jSInY77wA/edit?tab=t.0
 
 This quarter, we have participated in the discussions that led to the formation of the [ORBIT Launchpad](https://github.com/ossf/orbit-launchpad) effort. As noted in their charter, we see the Cyber Policy working group as a key stakeholder and partner for ORBIT Launchpad. This work has subsumed the work that we initially conceived of as a "Tooling" SIG in our own working group.
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -12,7 +12,7 @@ In late 2025, the group ran some workshop sessions at the LF Europe Roadshow eve
 
 We have two working group co-leads: [Daniel Appelquist | Samsung](https://github.com/torgo) and [Roman Zhukov | Red Hat](https://github.com/rozhukov). [Megan Knight | Arm](https://github.com/businesscasualkesha) chairs the Awareness SIG and [Madalin Neag](https://github.com/madalinnneag) from OpenSSF staff chairs the Standards SIG. In addition, we have support from [Jeff Diecks](https://github.com/GeauxJD], [Crob](https://github.com/SecurityCRob) and [David A. Wheeler](https://github.com/david-a-wheeler).
 
-We also operate the "EU CRA Monthly Tech Talk", the agenda of which is managed by the Awareness SIG.
+We also operate the "EU CRA Monthly Tech Talk".
 
 We have a regular schedule of calls for our Awareness and Standards SIGs and take minutes in our main minutes doc.
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -20,7 +20,10 @@ This quarter, we have participated in the discussions that led to the formation 
 
 Our general working group call, besides being a place where SIGs report, also serves as a venue to work on general deliverables and to drive awareness with group members of related activities. 
 
-Since our last report:
+Since our last report, we held two tech talks:
+
+* one where Launchpad SIG was presented. [Recording is available here](https://zoom.us/rec/share/X5PE2JoOyLac15HXB-0eGm9avCPSrRuwfmZD7Uy2QCwq5mYkAqla--O6_fD7eYcr.AL_bBxDGeZD8SejU) and the slides are [available here](https://drive.google.com/file/d/17b-dUihdJJ-i6URvY6mqLWKLq4Cata8B/view?usp=sharing)
+* one where we discussed our approach for stewardship and the documents that our community has developed. [Recording here](https://zoom.us/rec/play/vu7ETuGu10UZt3TUlZDNT597n8j8tEds1kFOjxOuLQimwYxHRf4nCcYFFbo54N_9qFOb4NfQdiIHR4fG.Br30pNufDbHGCo6P?eagerLoadZvaPages=sidemenu.billing.plan_management&accessLevel=meeting&canPlayFromShare=true&from=share_recording_detail&continueMode=true&componentName=rec-play&originRequestUrl=https%3A%2F%2Fzoom.us%2Frec%2Fshare%2FuiUTy3JAmVUI_CGYQFLXjhpeCUbsDrwb3J55n_IzFyBbKqSfuEyZ3yWi_ZUscVIz.qW8ITyi-A9YBLTvp)
 
 * We collaborated with others in a successful [CRA In Pracitce](https://fosdem.org/2026/schedule/track/cra-in-practice/) dev room at FOSDEM.
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -10,7 +10,7 @@ This group has celebrated its 1st year of operation, having been been formed in 
 
 In late 2025, the group ran some workshop sessions at the LF Europe Roadshow event in Ghent and subsequent policy summit in Brussels to refine its scope and deliverables for 2026. For example, we added an emphasis on case studies and producing guidelines that would be useful to "manufacturers."
 
-We have two working group co-leads: [Daniel Appelquist | Samsung](https://github.com/torgo) and [Roman Zhukov | Red Hat](https://github.com/rozhukov). [Megan Knight | Arm](https://github.com/businesscasualkesha) chairs the Awareness SIG and [Madalin Neag](https://github.com/madalinnneag) from OpenSSF staff chairs the Standards SIG. In addition, we have support from [Crob](https://github.com/SecurityCRob) and [Jeff Diecks](https://github.com/GeauxJD).
+We have two working group co-leads: [Daniel Appelquist | Samsung](https://github.com/torgo) and [Roman Zhukov | Red Hat](https://github.com/rozhukov). [Megan Knight | Arm](https://github.com/businesscasualkesha) chairs the Awareness SIG and [Madalin Neag](https://github.com/madalinnneag) from OpenSSF staff chairs the Standards SIG. In addition, we have support from [Jeff Diecks](https://github.com/GeauxJD], [Crob](https://github.com/SecurityCRob) and [David A. Wheeler](https://github.com/david-a-wheeler).
 
 We also operate the "EU CRA Monthly Tech Talk", the agenda of which is managed by the Awareness SIG.
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -65,7 +65,7 @@ The SIG's mission has been to coordinate between stakeholders regarding engageme
 
 The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members participate in these consultations.
 
-The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members partiicpate in these consulitations.
+The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members participate in these consultations.
 
 We are developing [Comments to the draft  Communication on Commission guidance on the application of the CRA](https://docs.google.com/spreadsheets/d/1UNVJ5o3snT1oV_bqLWSmlBYm1DCvysQJcwvBszPjzes/edit)
 Minutes available here: [SIG Minutes Document](https://docs.google.com/document/d/1XjE5VYdyIdH32T94ZQIj0Hf5btRiKG58z3jSInY77wA/view?tab=t.0).

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -16,7 +16,7 @@ We also operate the "EU CRA Monthly Tech Talk", the agenda of which is managed b
 
 We have a regular schedule of calls for our Awareness and Standards SIGs and take minutes in our main minutes doc.
 
-This quarter, we have participated in the discussions that led to the formation of the [ORBIT Launchpad](https://github.com/ossf/orbit-launchpad) effort. As noted in their charter, we see the Cyber Polict working group as a key stakeholder and partner for ORBIT Launchpad. This work has subsumed the work that we initially conceived of as a "Tooling" SIG in our own working group.
+This quarter, we have participated in the discussions that led to the formation of the [ORBIT Launchpad](https://github.com/ossf/orbit-launchpad) effort. As noted in their charter, we see the Cyber Policy working group as a key stakeholder and partner for ORBIT Launchpad. This work has subsumed the work that we initially conceived of as a "Tooling" SIG in our own working group.
 
 Our general working group call, besides being a place where SIGs report, also serves as a venue to work on general deliverables and to drive awareness with group members of related activities. 
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -41,6 +41,7 @@ Since our last report:
 The awareness SIG is led by [Megan Knight](https://github.com/businesscasualkesha) of Arm. The scope is activities that drive awareness of the work of this group and of the regulatory landscape in general. The SIG has been marshalling blog posts, upcoming conference schedule, as well as the CRA introductory course. The Awareness SIG minutes are kept in the [main working group minutes document](https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit). 
 
 Activities and Publications: [pending]
+* On 2026-02-25, Linux Foundation Member Summit, "CRA: Ask Us Anything" was led by Christopher "CRob" Robinson and David A. Wheeler; "Security through Education: Meeting AI, CRA, and Supply Chain Challenges in Software Development" was presented by David A. Wheeler
 
 ## Standards SIG
 
@@ -52,6 +53,7 @@ Last year, the SIG produced a Standards Survey for OpenSSF members to determine 
 
 The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members partiicpate in these consulitations.
 
+We are developing [Comments to the draft  Communication on Commission guidance on the application of the CRA](https://docs.google.com/spreadsheets/d/1UNVJ5o3snT1oV_bqLWSmlBYm1DCvysQJcwvBszPjzes/edit)
 Minutes available here: [SIG Minutes Document](https://docs.google.com/document/d/1XjE5VYdyIdH32T94ZQIj0Hf5btRiKG58z3jSInY77wA/view?tab=t.0).
 
 ## Questions/Issues for the TAC

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -1,0 +1,62 @@
+# 2026 Q4 TAC Report for Global Cyber Policy Working Group
+
+## Overview
+
+* GitHub repo: https://github.com/ossf/wg-globalcyberpolicy/
+* Minutes doc: https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit
+* Charter: https://github.com/ossf/wg-globalcyberpolicy/blob/main/CHARTER.md
+
+This group has celebrated its 1st year of operation, having been been formed in January 2025, after the Linux Foundation workshop on "Stewards and Manufacturers" in Amsterdam in December 2024. The scope of the group is to provide a forum for our members and the broader community to collaborate on Global Cybersecurity-related legislation, frameworks, and standards which facilitate conformance to regulatory requirements by open source projects and their consumers. We have been holding bi-weekly calls. We have 2 active SIGs - Awareness and Standards. The group is focusing most of its attention on the European Cyber Resilience Act (CRA) with some time put aside to monitor activities in other jurisdictions. We also have drafted a [liaisons list](https://github.com/ossf/wg-globalcyberpolicy/blob/main/governance/external-liaisons.md) which is a list of external organizations we feel we need to liaise with, with a special emphasis on the [Eclipse ORC working group](https://github.com/orcwg/), to minimize overlap.
+
+In late 2025, the group ran some workshop sessions at the LF Europe Roadshow event in Ghent and subsequent policy summit in Brussels to refine its scope and deliverables for 2026. For example, we added an emphasis on case studies and producing guidelines that would be useful to "manufacturers."
+
+We have two working group co-leads: [Daniel Appelquist | Samsung](https://github.com/torgo) and [Roman Zhukov | Red Hat](https://github.com/rozhukov). [Megan Knight | Arm](https://github.com/businesscasualkesha) chairs the Awareness SIG and [Madalin Neag](https://github.com/madalinnneag) from OpenSSF staff chairs the Standards SIG. In addition, we have support from [Crob](https://github.com/SecurityCRob) and [Jeff Diecks](https://github.com/GeauxJD).
+
+We also operate the "EU CRA Monthly Tech Talk", the agenda of which is managed by the Awareness SIG.
+
+We have a regular schedule of calls for our Awareness and Standards SIGs and take minutes in our main minutes doc.
+
+This quarter, we have participated in the discussions that led to the formation of the [ORBIT Launchpad](https://github.com/ossf/orbit-launchpad) effort. As noted in their charter, we see the Cyber Polict working group as a key stakeholder and partner for ORBIT Launchpad. This work has subsumed the work that we initially conceived of as a "Tooling" SIG in our own working group.
+
+Our general working group call, besides being a place where SIGs report, also serves as a venue to work on general deliverables and to drive awareness with group members of related activities. 
+
+Since our last report:
+
+* We collaborated with others in a successful [CRA In Pracitce](https://fosdem.org/2026/schedule/track/cra-in-practice/) dev room at FOSDEM.
+
+* We continued work on specifying a "compliance" file for OSS repos - that would include information about stewardship as well as additional info: https://github.com/ossf/wg-globalcyberpolicy/issues/69. It's already referenced as a "good practice" by the CRA Voluntary Security Attestation Project (Eclipse ORC WG)
+
+* We have updated the page at https://policy.openssf.org
+
+* We have helped to shape work by OpenSSF staff on Stewardship recommendations for LF Projects:
+  * [Stewards One-Pager](https://policy.openssf.org/CRA/stewards-one-pager.html)
+  * [Stewards Playbook](https://policy.openssf.org/CRA/stewards-playbook.html)
+
+* We have sent out numerous updates on activities in relevant standards organizations, and produced a [CRA Standards Map](https://policy.openssf.org/CRA/standards.html).
+
+* We have produced [blog posts](https://openssf.org/category/policy/cra/) including a case study from Red Hat.
+
+## Awareness SIG
+
+The awareness SIG is led by [Megan Knight](https://github.com/businesscasualkesha) of Arm. The scope is activities that drive awareness of the work of this group and of the regulatory landscape in general. The SIG has been marshalling blog posts, upcoming conference schedule, as well as the CRA introductory course. The Awareness SIG minutes are kept in the [main working group minutes document](https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit). 
+
+Activities and Publications: [pending]
+
+## Standards SIG
+
+The Standards SIG is led by [Madalin Neag](https://github.com/madalinnneag). 
+
+The SIG's mission has been to coordinate between stakeholders regarding engagement in Standards work related to cybersecurity policy. This is complicated by the fact that many of these standards organizations have a different approach to confidentiality than the OpenSSF. The discussions of this group have helped to guide the engagement of OpenSSF staff within some of these efforts.
+
+Last year, the SIG produced a Standards Survey for OpenSSF members to determine what standards are highest priority. The results of this survey were discussed in our main working group [call on 7-21](https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit?tab=t.0) and indicated high priority for certain vertical standards such as hypervisors, operating systems and identity management systems. This info has helped to prioritize the work of this group. 
+
+The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members partiicpate in these consulitations.
+
+Minutes available here: [SIG Minutes Document](https://docs.google.com/document/d/1XjE5VYdyIdH32T94ZQIj0Hf5btRiKG58z3jSInY77wA/view?tab=t.0).
+
+## Questions/Issues for the TAC
+
+None at this time.
+
+## Additional Information
+

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -61,7 +61,7 @@ The Standards SIG is led by [Madalin Neag](https://github.com/madalinnneag).
 
 The SIG's mission has been to coordinate between stakeholders regarding engagement in Standards work related to cybersecurity policy. This is complicated by the fact that many of these standards organizations have a different approach to confidentiality than the OpenSSF. The discussions of this group have helped to guide the engagement of OpenSSF staff within some of these efforts.
 
-Last year, the SIG produced a Standards Survey for OpenSSF members to determine what standards are highest priority. The results of this survey were discussed in our main working group [call on 7-21](https://docs.google.com/document/d/1iAplSQheMgemdMnEw74uPj3oi_6rLLbFFXhg4svqIDo/edit?tab=t.0) and indicated high priority for certain vertical standards such as hypervisors, operating systems and identity management systems. This info has helped to prioritize the work of this group. 
+Last year, the SIG produced a Standards Survey for OpenSSF members to determine what standards are highest priority. This info helped to prioritize the initial work of this group. The SIG has gone on to expand its area of focus in accordance with participants' priorities.
 
 The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members partiicpate in these consulitations.
 

--- a/TI-reports/2026/2026-Q1-GCP-WG.md
+++ b/TI-reports/2026/2026-Q1-GCP-WG.md
@@ -63,7 +63,7 @@ The Standards SIG is led by [Madalin Neag](https://github.com/madalinnneag).
 
 The SIG's mission has been to coordinate between stakeholders regarding engagement in Standards work related to cybersecurity policy. This is complicated by the fact that many of these standards organizations have a different approach to confidentiality than the OpenSSF. The discussions of this group have helped to guide the engagement of OpenSSF staff within some of these efforts.
 
-Last year, the SIG produced a Standards Survey for OpenSSF members to determine what standards are highest priority. This info helped to prioritize the initial work of this group. The SIG has gone on to expand its area of focus in accordance with participants' priorities.
+The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members participate in these consultations.
 
 The SIG's main work this year has been on raising awareness of relevant standards efforts, disseminating information to members about these efforts, and highligting when public consultations are open / helping members partiicpate in these consulitations.
 


### PR DESCRIPTION
This draft report outlines the activities and focus areas of the Global Cyber Policy Working Group for Q1 2026, including collaboration on the European Cyber Resilience Act and updates on the Awareness and Standards SIGs. We still need some additional feedback from wg members.