### PR TITLE
Transition Malicious Packages under Securing Software Repositories WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following Technical Initiatives have been approved by the TAC. You may learn
 | OpenSSF Scorecard | [GitHub](https://github.com/ossf/scorecard)                | https://securityscorecards.dev/ | Best Practices WG | [Incubating](process/project-lifecycle-documents/openssf_scorecard_incubating_stage.md) |
 | OpenVEX | [GitHub](https://github.com/openvex) |  | Vulnerability Disclosures WG | [Sandbox](process/project-lifecycle-documents/openvex_for_sandbox_stage.md) |
 | OSV Schema             | [GitHub](https://github.com/ossf/osv-schema)               | https://ossf.github.io/osv-schema/ | Vulnerability Disclosures WG   | TBD        |
-| Malicious Packages     | [GitHub](https://github.com/ossf/malicious-packages)       |  | Securing Critical Projects WG             | [Sandbox](process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md) |
+| Malicious Packages     | [GitHub](https://github.com/ossf/malicious-packages)       |  | Securing Software Repositories WG             | [Sandbox](process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md) |
 | Minder                 | [GitHub](https://github.com/mindersec/minder)         | https://mindersec.dev/ | ORBIT WG            | [Sandbox](process/project-lifecycle-documents/minder_sandbox_stage.md) |
 | Model signing          | [GitHub](https://github.com/sigstore/model-transparency/blob/main/README.model_signing.md) |  | AI/ML Security WG | [Sandbox](process/project-lifecycle-documents/model_signing_sandbox_stage.md) |
 | SAFE-Framework         | [GitHub](https://github.com/SAFE-MCP/safe-mcp) |  | AI/ML Security WG | [Sandbox](process/project-lifecycle-documents/safe_framework_sandbox_stage.md) |

--- a/organizational-structure-overview.md
+++ b/organizational-structure-overview.md
@@ -80,6 +80,7 @@ flowchart LR
        BPB[Best Practices Badge]
        SI[Security Insights]
        SM[Security Metrics]
+       MP[Malicious Packages]
        Rstuf[Repository Service for TUF]
        Gittuf[gittuf]
        GUAC[GUAC]
@@ -104,6 +105,7 @@ flowchart LR
     BP --> BPB
     MM --> SI
     MM --> SM
+    REP --> MP
     REP --> Rstuf
     SCI --> Gittuf
     SCI --> GUAC

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -8,7 +8,7 @@
 
 ### Sponsor
 
-  * Securing Critical Projects Working Group
+  * Securing Software Repositories Working Group
 
 ### Mission of the project
 


### PR DESCRIPTION
This will effectively move the Malicious Packages project from the Securing Critical Projects WG to the Securing Software Repositories WG.