### PR TITLE
Add Q2 2026 report for Vulnerability Disclosures WG

### DIFF
--- a/TI-reports/2026/2026-Q2-VD-WG.md
+++ b/TI-reports/2026/2026-Q2-VD-WG.md
@@ -12,6 +12,8 @@ Building on [Q1](https://github.com/ossf/tac/blob/main/TI-reports/2026/2026-Q1-V
 
 ## Activity #1 — AI Slop Guidance / Best Practices for Open Source Maintainers
 
+https://github.com/ossf/wg-vulnerability-disclosures/issues/178
+
 ### Purpose
 
 To develop best current practices for open source maintainers on how to effectively handle the wave of high-volume, AI-supported vulnerability submissions, and to improve submission quality from finders. This evolves the Q1 "AI-Generated Report Quality" workstream from problem-framing into actionable guidance.
@@ -41,9 +43,12 @@ Not applicable for this activity.
 
 ## Activity #2 — Ortelius Project Transfer
 
+https://github.com/ortelius/ortelius
+https://ortelius.io/
+
 ### Purpose
 
-The Ortelius OS project is seeking to move from the Continuous Delivery Foundation (CDF) to OpenSSF under this WG. Ortelius focuses on post-deployment vulnerability remediation and tracking vulnerabilities on live systems, which aligns with the VDWG's portfolio. *(New activity this quarter — not present in Q1.)*
+The Ortelius OS project is seeking to move from the [Continuous Delivery Foundation (CDF)](https://cd.foundation/) to OpenSSF under this WG. Ortelius focuses on post-deployment vulnerability remediation and tracking vulnerabilities on live systems, which aligns with the VDWG's portfolio. *(New activity this quarter — not present in Q1.)*
 
 ### Current Status
 
@@ -65,6 +70,8 @@ Not applicable.
 
 ## Activity #3 — OSV Project (Schema and Database)
 
+https://github.com/ossf/osv-schema
+
 ### Purpose
 
 To maintain and advance the OSV schema and database so they meet current standards and community needs. This continues the Q1 OSV Schema Graduation workstream, now also covering ongoing schema evolution.
@@ -83,6 +90,7 @@ To maintain and advance the OSV schema and database so they meet current standar
 
 - Continue schema updates, including a formal field for **reachability symbols**.
 - Complete the remaining work required to achieve **OpenSSF Security Baseline Level 2**.
+- Security Baseline 3 Tracking Milestone: https://github.com/ossf/osv-schema/milestone/1
 
 ### Funding requests and updates
 

--- a/TI-reports/2026/2026-Q2-VD-WG.md
+++ b/TI-reports/2026/2026-Q2-VD-WG.md
@@ -1,0 +1,108 @@
+# 2026 Q2 Vulnerability Disclosures WG
+
+## Overview
+
+**Mission**: The OpenSSF Vulnerability Disclosures Working Group seeks to help improve the overall security of the open source software ecosystem by helping mature and advocate well-managed vulnerability reporting and communication.
+
+The Vulnerability Disclosures WG remains a [Graduated-level](https://github.com/ossf/tac/blob/main/process/working-group-lifecycle.md) Technical Initiative. Community health is stable: AMER and APAC meetings continue to be well-attended, and a new OSV-specific APAC-friendly meeting was added on alternating weeks to make progress on OSV issues.
+
+Building on [Q1](https://github.com/ossf/tac/blob/main/TI-reports/2026/2026-Q1-VD-WG.md), the WG's primary focus this quarter shifted from simply identifying the "AI slop" problem to producing concrete best-practice guidance for maintainers and finders. The surge in AI-assisted vulnerability reports has reached a sustainability tipping point — major projects including **Node.js**, **Express**, and the **Apache Software Foundation** have paused their bug bounty programs as a result. In parallel, the WG is reviewing a transfer request from the **Ortelius** project. **OSV schema graduation** work continues, with the team now finalizing TAC paperwork and pushing toward OpenSSF Security Baseline Level 2.
+
+**WG Project Board:** https://github.com/orgs/ossf/projects/29
+
+## Activity #1 — AI Slop Guidance / Best Practices for Open Source Maintainers
+
+### Purpose
+
+To develop best current practices for open source maintainers on how to effectively handle the wave of high-volume, AI-supported vulnerability submissions, and to improve submission quality from finders. This evolves the Q1 "AI-Generated Report Quality" workstream from problem-framing into actionable guidance.
+
+### Current Status
+
+- The framing has shifted from solely combating "AI slop" to **producing guidance** — both for maintainers (improving `SECURITY.md`, threat models, and other repo documentation to help filter reports) and for researchers (how to submit higher-quality reports).
+- A collaborative working draft, "[AI Slop: Best Practices for Open Source Maintainers](https://docs.google.com/document/d/1csseaiMVQeILSPjx3BvpCBH88PifgPf_ebXVKD5DIOs/edit?usp=sharing)," is in progress.
+- The **AI-Slop Impact community survey** ([issue #181](https://github.com/ossf/wg-vulnerability-disclosures/issues/181)) was promoted across the community and is scheduled to close **May 31, 2026**.
+- The WG is actively seeking contacts at major AI vendors (e.g., OpenAI, Anthropic) to provide direct feedback on improving vulnerability research tooling.
+- Context: major projects (Node.js, Express, ASF) have **paused bug bounties** in response to the volume of AI-assisted reports.
+
+### Up Next
+
+- Finalize and integrate the draft AI guidance into (a) a comprehensive guide for maintainers and (b) a concise guide for finders.
+- Submit a PR to update the WG's contributing guide to include the new Google Docs workflow.
+- Convert the existing Slack list of free maintainer resources into a wiki page in the WG repo.
+- Analyze and publish results of the AI-Slop Impact survey after it closes May 31.
+
+### Funding requests and updates
+
+Not applicable for this activity.
+
+### Questions/Issues for the TAC
+
+- The WG is actively grappling with the sustainability challenge presented by the volume of AI-assisted vulnerability reports, which has already caused major projects (Node.js, Express, ASF) to pause bug bounties. **The WG is seeking broader OpenSSF attention and coordination on this trend** to help ensure open source project sustainability.
+
+## Activity #2 — Ortelius Project Transfer
+
+### Purpose
+
+The Ortelius OS project is seeking to move from the Continuous Delivery Foundation (CDF) to OpenSSF under this WG. Ortelius focuses on post-deployment vulnerability remediation and tracking vulnerabilities on live systems, which aligns with the VDWG's portfolio. *(New activity this quarter — not present in Q1.)*
+
+### Current Status
+
+- The project was introduced and demonstrated during a WG meeting.
+- The WG has outlined a formal adoption process, beginning with a PR using the project sandbox template.
+
+### Up Next
+
+- Ortelius CEO Tracy Ragan is scheduled to provide a short demo at an upcoming WG meeting.
+- WG leadership will work with the Ortelius team to execute the adoption process, beginning with creating a PR in the WG repository.
+
+### Funding requests and updates
+
+Not applicable.
+
+### Questions/Issues for the TAC
+
+- None at this time; the WG will follow the standard project intake/sandbox process.
+
+## Activity #3 — OSV Project (Schema and Database)
+
+### Purpose
+
+To maintain and advance the OSV schema and database so they meet current standards and community needs. This continues the Q1 OSV Schema Graduation workstream, now also covering ongoing schema evolution.
+
+### Current Status
+
+- The OSV schema team is **finalizing their TAC paperwork** for graduation to a Graduated TI (continuing the [graduation PR](https://github.com/ossf/tac/pull/456) reported in Q1).
+- The team met to discuss security baseline and lifecycle documentation, targeting **OpenSSF Security Baseline Level 2**.
+- Schema discussions this quarter included:
+  - Adding **Ruby** (Rubies) as an ecosystem.
+  - Defining a **severity source** field.
+  - Representing **end-of-life (EOL)** in OSV records.
+- A new **OSV-specific APAC-friendly meeting** on alternating weeks was added to the calendar to make progress on OSV issues.
+
+### Up Next
+
+- Continue schema updates, including a formal field for **reachability symbols**.
+- Complete the remaining work required to achieve **OpenSSF Security Baseline Level 2**.
+
+### Funding requests and updates
+
+Not applicable.
+
+### Questions/Issues for the TAC
+
+- None at this time.
+
+## Funding requests and updates (WG-level)
+
+The WG is not currently considering applying for funding. However, the group was informed of an opportunity for C or C++ open source projects to receive a small grant for time spent participating and giving feedback to a team developing security tools. This opportunity was shared by Jeff Diecks (OpenSSF) and interested projects should contact him for details.
+
+## Additional Information
+
+- **New tooling:** Chris de Almeida demoed **[CVE-Kit](https://github.com/ctcpip/cve-kit)**, a tool for managing CVEs that aligns with GitHub Security Advisories.
+- **External collaboration:** Dick Brooks shared updates on a **North American Energy Standards Board (NAESB)** initiative developing contract language that would require confidential notification of confirmed exploitable vulnerabilities to customers within a short window (e.g., 72 hours).
+- **Maintainer Contact Info / CRA (status note):** The Q1 "Maintainer Contact Info & CRA Compliance" workstream ([issue #175](https://github.com/ossf/wg-vulnerability-disclosures/issues/175)) remains open; no major status change to report this quarter as WG attention concentrated on the AI guidance effort. It will be picked back up next quarter.
+- **VDWG Automation Best Practices SIG (status note):** Still under evaluation as reported in Q1; no formalization yet.
+- **The Criticality Score project** was added to the Package Analysis projects - https://github.com/ossf/tac/pull/594.
+
+### Previous Updates
+- [2026 Q1](https://github.com/ossf/tac/blob/main/TI-reports/2026/2026-Q1-VD-WG.md)


### PR DESCRIPTION
This document outlines the activities and focus areas of the Vulnerability Disclosures Working Group for Q2 2026, including guidance on AI-assisted vulnerability submissions and the Ortelius project transfer.